### PR TITLE
Fixes for network and configuration plugins

### DIFF
--- a/android/example/src/main/java/com/example/myapplication/MainActivity.kt
+++ b/android/example/src/main/java/com/example/myapplication/MainActivity.kt
@@ -33,14 +33,14 @@ class MainActivity : AppCompatActivity() {
 
         // 1️⃣ Debug in emulator with a server running on the host machine on localhost:1234
         // Run `npm start` in `<racehorse>/web/example` then start the app in emulator.
-        webView.start("https://10.0.2.2:1234")
+        webView.loadApp("https://10.0.2.2:1234")
         setContentView(webView)
 
 /*
         // 2️⃣ Load app bundle from src/main/assets folder
         // Run `num run build` in `<racehorse>/web/example`, copy files from `<racehorse>/web/example/dist` to
         // `<racehorse>/android/example/src/main/assets`, then start the app in emulator.
-        webView.start(
+        webView.loadApp(
             "http://example.com",
             WebViewAssetLoader.Builder()
                 .setDomain("example.com")
@@ -69,18 +69,21 @@ class MainActivity : AppCompatActivity() {
 
     override fun onStart() {
         super.onStart()
+
         networkMonitor.start()
+        webView.startPlugins()
     }
 
     override fun onPause() {
         super.onPause()
+
         networkMonitor.stop()
-        webView.pause()
+        webView.pausePlugins()
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     fun onBundleReadyEvent(event: BundleReadyEvent) {
-        webView.start(
+        webView.loadApp(
             "https://example.com",
             WebViewAssetLoader.Builder()
                 .setDomain("example.com")

--- a/android/racehorse/build.gradle.kts
+++ b/android/racehorse/build.gradle.kts
@@ -77,7 +77,7 @@ publishing {
 dependencies {
     implementation("androidx.core:core-ktx:1.9.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("androidx.webkit:webkit:1.6.0")
+    implementation("androidx.webkit:webkit:1.6.1")
     implementation("org.greenrobot:eventbus:3.3.1")
     implementation("com.google.code.gson:gson:2.8.9")
     implementation("com.android.installreferrer:installreferrer:2.2")

--- a/android/racehorse/src/main/java/org/racehorse/ActionsPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/ActionsPlugin.kt
@@ -10,11 +10,11 @@ import org.racehorse.utils.excludePackage
 import org.racehorse.webview.*
 
 /**
- * Opens URL in the external application.
+ * Opens URL in the external app.
  */
 class OpenUrlRequestEvent(val url: String) : RequestEvent()
 
-class OpenUrlResponseEvent(val opened: Boolean) : ResponseEvent()
+class OpenUrlResponseEvent(val isOpened: Boolean) : ResponseEvent()
 
 /**
  * Launches activities for various intents.
@@ -22,7 +22,7 @@ class OpenUrlResponseEvent(val opened: Boolean) : ResponseEvent()
 open class ActionsPlugin(private val activity: ComponentActivity) : Plugin(), EventBusCapability, OpenUrlCapability {
 
     /**
-     * Tries to open [uri] in an external application.
+     * Tries to open [uri] in an external app.
      *
      * @return `true` if an external activity has started, or `false` otherwise.
      */

--- a/android/racehorse/src/main/java/org/racehorse/ConfigurationPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/ConfigurationPlugin.kt
@@ -20,22 +20,22 @@ class GetWindowInsetsRequestEvent(
 
 class GetWindowInsetsResponseEvent(val rect: Rect) : ResponseEvent()
 
-class KeyboardVisibilityChangedAlertEvent(val keyboardVisible: Boolean) : AlertEvent
+class KeyboardVisibilityChangedAlertEvent(val isKeyboardVisible: Boolean) : AlertEvent
 
 class Rect(val top: Float, val right: Float, val bottom: Float, val left: Float)
 
 /**
  * Device configuration and general information.
  */
-class ConfigurationPlugin(private val activity: ComponentActivity) : Plugin(), EventBusCapability {
+open class ConfigurationPlugin(private val activity: ComponentActivity) : Plugin(), EventBusCapability {
 
-    private var keyboardVisible = false
+    private var isKeyboardVisible = false
 
     private val keyboardListener = View.OnApplyWindowInsetsListener { _, windowInsets ->
         with(toWindowInsetsCompat(windowInsets).getInsets(WindowInsetsCompat.Type.ime())) {
-            if (keyboardVisible != (top + right + bottom + left != 0)) {
-                keyboardVisible = !keyboardVisible
-                eventBus.post(KeyboardVisibilityChangedAlertEvent(keyboardVisible))
+            if (isKeyboardVisible != (top + right + bottom + left != 0)) {
+                isKeyboardVisible = !isKeyboardVisible
+                eventBus.post(KeyboardVisibilityChangedAlertEvent(isKeyboardVisible))
             }
         }
         windowInsets

--- a/android/racehorse/src/main/java/org/racehorse/FileChooserPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/FileChooserPlugin.kt
@@ -67,13 +67,13 @@ open class FileChooserPlugin(
         private val multiple = fileChooserParams.mode == FileChooserParams.MODE_OPEN_MULTIPLE
         private val mimeType = fileChooserParams.acceptTypes.joinToString(",")
 
-        private val anyRequested = mimeType == "" || mimeType.contains("*/*")
-        private val imageRequested = anyRequested || mimeType.contains("image/")
-        private val videoRequested = anyRequested || mimeType.contains("video/")
+        private val isWildcard = mimeType == "" || mimeType.contains("*/*")
+        private val isImage = isWildcard || mimeType.contains("image/")
+        private val isVideo = isWildcard || mimeType.contains("video/")
 
         fun start() {
             if (
-                !imageRequested && !videoRequested ||
+                !isImage && !isVideo ||
                 !(cacheDir != null && authority != null && activity.packageManager.hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY))
             ) {
                 // No camera-related MIME types, camera isn't supported, or capture result cannot be saved
@@ -112,13 +112,13 @@ open class FileChooserPlugin(
 
                     val fileUri = FileProvider.getUriForFile(activity, authority, file)
 
-                    val imageIntent = if (anyRequested || imageRequested) {
+                    val imageIntent = if (isImage) {
                         Intent(MediaStore.ACTION_IMAGE_CAPTURE)
                             .setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
                             .putExtra(MediaStore.EXTRA_OUTPUT, fileUri)
                     } else null
 
-                    val videoIntent = if (anyRequested || videoRequested) {
+                    val videoIntent = if (isVideo) {
                         Intent(MediaStore.ACTION_VIDEO_CAPTURE)
                             .setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
                             .putExtra(MediaStore.EXTRA_OUTPUT, fileUri)

--- a/android/racehorse/src/main/java/org/racehorse/FileChooserPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/FileChooserPlugin.kt
@@ -64,12 +64,12 @@ open class FileChooserPlugin(
         fileChooserParams: FileChooserParams,
     ) {
 
-        private val multiple = fileChooserParams.mode == FileChooserParams.MODE_OPEN_MULTIPLE
+        private val isMultiple = fileChooserParams.mode == FileChooserParams.MODE_OPEN_MULTIPLE
+
         private val mimeType = fileChooserParams.acceptTypes.joinToString(",")
 
-        private val isWildcard = mimeType == "" || mimeType.contains("*/*")
-        private val isImage = isWildcard || mimeType.contains("image/")
-        private val isVideo = isWildcard || mimeType.contains("video/")
+        private val isImage = mimeType.isEmpty() || mimeType.contains("*/*") || mimeType.contains("image/")
+        private val isVideo = mimeType.isEmpty() || mimeType.contains("*/*") || mimeType.contains("video/")
 
         fun start() {
             if (
@@ -101,7 +101,7 @@ open class FileChooserPlugin(
             var intent = Intent(Intent.ACTION_GET_CONTENT)
                 .setType(mimeType)
                 .addCategory(Intent.CATEGORY_OPENABLE)
-                .putExtra(Intent.EXTRA_ALLOW_MULTIPLE, multiple)
+                .putExtra(Intent.EXTRA_ALLOW_MULTIPLE, isMultiple)
 
             if (cameraEnabled && cacheDir != null && authority != null) {
                 try {

--- a/android/racehorse/src/main/java/org/racehorse/FirebasePlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/FirebasePlugin.kt
@@ -13,7 +13,7 @@ class GetFirebaseTokenRequestEvent : RequestEvent()
 
 class GetFirebaseTokenResponseEvent(val token: String?) : ResponseEvent()
 
-class FirebasePlugin : Plugin(), EventBusCapability {
+open class FirebasePlugin : Plugin(), EventBusCapability {
 
     @Subscribe
     fun onGetFirebaseTokenRequestEvent(event: GetFirebaseTokenRequestEvent) {

--- a/android/racehorse/src/main/java/org/racehorse/GooglePlayReferrerPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/GooglePlayReferrerPlugin.kt
@@ -24,28 +24,34 @@ class GooglePlayReferrerPlugin : Plugin(), EventBusCapability {
     private val preferences
         get() = context.getSharedPreferences(GooglePlayReferrerPlugin::class.java.name, Context.MODE_PRIVATE)
 
-    override fun onStart() {
-        super.onStart()
-
-        val referrerClient = InstallReferrerClient.newBuilder(context).build()
-
-        referrerClient.startConnection(object : InstallReferrerStateListener {
-
-            override fun onInstallReferrerSetupFinished(responseCode: Int) {
-                if (responseCode == InstallReferrerClient.InstallReferrerResponse.OK) {
-                    val referrer = referrerClient.installReferrer.installReferrer
-
-                    preferences.edit().putString(GOOGLE_PLAY_REFERRER_KEY, referrer).apply()
-                    post(GooglePlayReferrerDetectedAlertEvent(referrer))
-                }
-            }
-
-            override fun onInstallReferrerServiceDisconnected() {}
-        })
-    }
+    private var referrerClient: InstallReferrerClient? = null
 
     @Subscribe
     fun onGetGooglePlayReferrerRequestEvent(event: GetGooglePlayReferrerRequestEvent) {
-        postToChain(event, GetGooglePlayReferrerResponseEvent(preferences.getString(GOOGLE_PLAY_REFERRER_KEY, null)))
+        val referrer = preferences.getString(GOOGLE_PLAY_REFERRER_KEY, null)
+
+        postToChain(event, GetGooglePlayReferrerResponseEvent(referrer))
+
+        if (referrer != null || referrerClient != null) {
+            return
+        }
+
+        referrerClient = InstallReferrerClient.newBuilder(context).build().apply {
+            startConnection(object : InstallReferrerStateListener {
+
+                override fun onInstallReferrerSetupFinished(responseCode: Int) {
+                    if (responseCode != InstallReferrerClient.InstallReferrerResponse.OK) {
+                        return
+                    }
+
+                    val installReferrer = installReferrer.installReferrer
+
+                    preferences.edit().putString(GOOGLE_PLAY_REFERRER_KEY, installReferrer).apply()
+                    post(GooglePlayReferrerDetectedAlertEvent(installReferrer))
+                }
+
+                override fun onInstallReferrerServiceDisconnected() {}
+            })
+        }
     }
 }

--- a/android/racehorse/src/main/java/org/racehorse/GooglePlayReferrerPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/GooglePlayReferrerPlugin.kt
@@ -15,7 +15,7 @@ class GooglePlayReferrerDetectedAlertEvent(val referrer: String) : AlertEvent
 /**
  * Gets [Google Play referrer](https://developer.android.com/google/play/installreferrer/library) information.
  */
-class GooglePlayReferrerPlugin : Plugin(), EventBusCapability {
+open class GooglePlayReferrerPlugin : Plugin(), EventBusCapability {
 
     companion object {
         const val GOOGLE_PLAY_REFERRER_KEY = "googlePlayReferrer"

--- a/android/racehorse/src/main/java/org/racehorse/HttpsPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/HttpsPlugin.kt
@@ -6,7 +6,7 @@ import android.webkit.WebView
 import org.racehorse.webview.HttpsCapability
 import org.racehorse.webview.Plugin
 
-class HttpsPlugin : Plugin(), HttpsCapability {
+open class HttpsPlugin : Plugin(), HttpsCapability {
 
     override fun onReceivedSslError(webView: WebView, handler: SslErrorHandler, error: SslError): Boolean {
         // TODO Validate public keys

--- a/android/racehorse/src/main/java/org/racehorse/NetworkPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/NetworkPlugin.kt
@@ -21,6 +21,14 @@ class OnlineStatusChangedAlertEvent(val isOnline: Boolean) : AlertEvent
  */
 open class NetworkPlugin(private val networkMonitor: NetworkMonitor) : Plugin(), EventBusCapability {
 
+    override fun onStart() {
+        networkMonitor.start()
+    }
+
+    override fun onPause() {
+        networkMonitor.stop()
+    }
+
     @Subscribe
     fun onIsOnlineRequestEvent(event: IsOnlineRequestEvent) {
         postToChain(event, IsOnlineResponseEvent(networkMonitor.isOnline))

--- a/android/racehorse/src/main/java/org/racehorse/PermissionsPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/PermissionsPlugin.kt
@@ -32,7 +32,7 @@ class AskForPermissionResponseEvent(val statuses: Map<String, Boolean>) : Respon
 /**
  * Check permission statuses and ask for permissions.
  */
-class PermissionsPlugin(private val activity: ComponentActivity) : Plugin(), EventBusCapability, PermissionsCapability {
+open class PermissionsPlugin(private val activity: ComponentActivity) : Plugin(), EventBusCapability, PermissionsCapability {
 
     override fun onAskForPermissions(
         permissions: Array<String>,

--- a/android/racehorse/src/main/java/org/racehorse/PermissionsPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/PermissionsPlugin.kt
@@ -23,7 +23,7 @@ class IsPermissionGrantedRequestEvent(val permissions: Array<String>) : RequestE
 class IsPermissionGrantedResponseEvent(val statuses: Map<String, Boolean>) : ResponseEvent()
 
 /**
- * Requests permissions to be granted to the application.
+ * Requests permissions to be granted to the app.
  */
 class AskForPermissionRequestEvent(val permissions: Array<String>) : RequestEvent()
 

--- a/android/racehorse/src/main/java/org/racehorse/evergreen/Bootstrapper.kt
+++ b/android/racehorse/src/main/java/org/racehorse/evergreen/Bootstrapper.kt
@@ -4,10 +4,9 @@ import java.io.File
 import java.net.URLConnection
 
 /**
- * Manages the app start process, downloads and unzips updates, handles mandatory and background updates, swaps app
- * bundles after restart.
+ * Manages the app start process: downloads and unzips update bundles and handles mandatory and background updates.
  *
- * @param bundlesDir The directory where bootstrapper sores app bundles.
+ * @param bundlesDir The directory where bootstrapper stores app bundles.
  */
 open class Bootstrapper(private val bundlesDir: File) {
 
@@ -23,7 +22,7 @@ open class Bootstrapper(private val bundlesDir: File) {
     private var updateDownload: BundleDownload? = null
 
     /**
-     * The app assets are ready to be used in [appDir].
+     * App assets available in [appDir] and are ready to be used.
      */
     protected open fun onBundleReady(appDir: File) {}
 
@@ -38,7 +37,7 @@ open class Bootstrapper(private val bundlesDir: File) {
     protected open fun onUpdateFailed(mandatory: Boolean, cause: Throwable) {}
 
     /**
-     * An update was successfully downloaded.
+     * A non-mandatory update was successfully downloaded and ready to be applied.
      */
     protected open fun onUpdateReady() {}
 
@@ -51,8 +50,8 @@ open class Bootstrapper(private val bundlesDir: File) {
      * Starts/restarts the bundle provisioning process.
      *
      * @param version The expected version of the app bundle.
-     * @param mandatory If `true` then the app must not start if version isn't [version], otherwise the app can start
-     * if any bundle is available, and update is downloaded in the background.
+     * @param mandatory If `true` then the app must not start if available bundle version isn't [version], otherwise the
+     * app can start if any bundle is available, and update is downloaded in the background.
      * @param openConnection Returns connection that downloads the bundle ZIP archive.
      */
     fun start(
@@ -105,9 +104,9 @@ open class Bootstrapper(private val bundlesDir: File) {
     }
 
     /**
-     * Applies update it it is available.
+     * Applies update if it is available.
      *
-     * @return `true` is update was applied, or `false` if there is no update to apply.
+     * @return `true` if update was applied, or `false` if there is no update to apply.
      */
     private fun applyUpdate(): Boolean {
         if (!updateDir.exists() || updateDownload != null) {

--- a/android/racehorse/src/main/java/org/racehorse/evergreen/Bootstrapper.kt
+++ b/android/racehorse/src/main/java/org/racehorse/evergreen/Bootstrapper.kt
@@ -23,7 +23,7 @@ open class Bootstrapper(private val bundlesDir: File) {
     private var updateDownload: BundleDownload? = null
 
     /**
-     * Application assets are ready to be used in [appDir].
+     * The app assets are ready to be used in [appDir].
      */
     protected open fun onBundleReady(appDir: File) {}
 

--- a/android/racehorse/src/main/java/org/racehorse/evergreen/BundleDownload.kt
+++ b/android/racehorse/src/main/java/org/racehorse/evergreen/BundleDownload.kt
@@ -10,7 +10,7 @@ import java.util.zip.ZipInputStream
 /**
  * Downloads ZIP archive through the [connection] and extracts its contents to [targetDir].
  *
- * [targetDir] is created only after all operations have bee completed and all contents are ready to be consumed.
+ * [targetDir] is created only after all operations have been completed and archive contents are ready to be consumed.
  */
 internal class BundleDownload(
     private val connection: URLConnection,

--- a/android/racehorse/src/main/java/org/racehorse/evergreen/RacehorseBootstrapper.kt
+++ b/android/racehorse/src/main/java/org/racehorse/evergreen/RacehorseBootstrapper.kt
@@ -4,16 +4,37 @@ import org.greenrobot.eventbus.EventBus
 import org.racehorse.webview.AlertEvent
 import java.io.File
 
+/**
+ * App assets available in [appDir] and are ready to be used.
+ */
 class BundleReadyEvent(val appDir: File)
 
-class UpdateFailedAlertEvent(val mandatory: Boolean, @Transient val cause: Throwable) : AlertEvent
-
-class UpdateProgressAlertEvent(val contentLength: Int, val readLength: Long) : AlertEvent
-
-class UpdateReadyAlertEvent : AlertEvent
-
+/**
+ * The new update download has started.
+ */
 class UpdateStartedAlertEvent(val mandatory: Boolean) : AlertEvent
 
+/**
+ * Failed to download an update.
+ */
+class UpdateFailedAlertEvent(val mandatory: Boolean, @Transient val cause: Throwable) : AlertEvent
+
+/**
+ * A non-mandatory update was successfully downloaded and ready to be applied.
+ */
+class UpdateReadyAlertEvent : AlertEvent
+
+/**
+ * A progress of a pending update download.
+ */
+class UpdateProgressAlertEvent(val contentLength: Int, val readLength: Long) : AlertEvent
+
+/**
+ * The [Bootstrapper] that posts status events to the [eventBus].
+ *
+ * @param bundlesDir The directory where bootstrapper stores app bundles.
+ * @param eventBus The event bus to which status events are posted
+ */
 class RacehorseBootstrapper(bundlesDir: File, private val eventBus: EventBus) : Bootstrapper(bundlesDir) {
 
     override fun onBundleReady(appDir: File) {

--- a/android/racehorse/src/main/java/org/racehorse/webview/AppWebView.kt
+++ b/android/racehorse/src/main/java/org/racehorse/webview/AppWebView.kt
@@ -21,6 +21,12 @@ class AppWebView(
         const val CONNECTION_KEY = "racehorseConnection"
     }
 
+    /**
+     * `true` if the [loadApp] was called, or `false` otherwise.
+     */
+    var isAppLoaded = false
+        private set
+
     private val plugins = ArrayList<Plugin>()
     private val cookieManager = CookieManager.getInstance()
 
@@ -39,22 +45,30 @@ class AppWebView(
     }
 
     /**
-     * Starts the application that is loaded from [appUrl]. Use IP `10.0.2.2` to load content from the host machine of
-     * the Android device emulator. [assetLoader] intercepts all requests
+     * Loads the app from [appUrl].
+     *
+     * Use IP `10.0.2.2` to load content from the host machine of the Android device emulator.
      */
-    fun start(appUrl: String, assetLoader: WebViewAssetLoader? = null) {
+    fun loadApp(appUrl: String, assetLoader: WebViewAssetLoader? = null) {
+        isAppLoaded = true
+
         webChromeClient = AppWebChromeClient()
         webViewClient = AppWebViewClient(appUrl, assetLoader)
 
         loadUrl(appUrl)
+    }
 
+    /**
+     * Starts all plugins.
+     */
+    fun startPlugins() {
         plugins.forEach(Plugin::onStart)
     }
 
     /**
-     * Persists application data and pauses all plugins.
+     * Persists app data and pauses all plugins.
      */
-    fun pause() {
+    fun pausePlugins() {
         cookieManager.flush()
         plugins.forEach(Plugin::onPause)
     }

--- a/android/racehorse/src/main/java/org/racehorse/webview/OpenUrlCapability.kt
+++ b/android/racehorse/src/main/java/org/racehorse/webview/OpenUrlCapability.kt
@@ -3,7 +3,7 @@ package org.racehorse.webview
 import android.net.Uri
 
 /**
- * Plugins with this capability allow user to open URLs in external applications.
+ * Plugins with this capability allow user to open URLs in external apps.
  */
 interface OpenUrlCapability {
 

--- a/web/racehorse/src/main/createActionsManager.ts
+++ b/web/racehorse/src/main/createActionsManager.ts
@@ -21,7 +21,7 @@ export function createActionsManager(eventBridge: EventBridge): ActionsManager {
     openUrl(url) {
       return eventBridge
         .request({ type: 'org.racehorse.OpenUrlRequestEvent', url })
-        .then(event => ensureEvent(event).opened);
+        .then(event => ensureEvent(event).isOpened);
     },
   };
 }

--- a/web/racehorse/src/main/createConfigurationManager.ts
+++ b/web/racehorse/src/main/createConfigurationManager.ts
@@ -24,6 +24,11 @@ export interface ConfigurationManager {
    * @param defaultLocale The default locale that is returned if there's no matching locale among preferred.
    */
   pickLocale(supportedLocales: string[], defaultLocale: string): Promise<string>;
+
+  /**
+   * Subscribes a listener to soft keyboard visibility changes.
+   */
+  subscribeToKeyboardVisibility(listener: (keyboardVisible: boolean) => void): () => void;
 }
 
 /**
@@ -42,6 +47,14 @@ export function createConfigurationManager(eventBridge: EventBridge): Configurat
       return eventBridge
         .request({ type: 'org.racehorse.GetWindowInsetsRequestEvent' })
         .then(event => ensureEvent(event).rect);
+    },
+
+    subscribeToKeyboardVisibility(listener) {
+      return eventBridge.subscribe(event => {
+        if (event.type === 'org.racehorse.KeyboardVisibilityChangedAlertEvent') {
+          listener(event.keyboardVisible);
+        }
+      });
     },
 
     getPreferredLocales,

--- a/web/racehorse/src/main/createConfigurationManager.ts
+++ b/web/racehorse/src/main/createConfigurationManager.ts
@@ -52,7 +52,7 @@ export function createConfigurationManager(eventBridge: EventBridge): Configurat
     subscribeToKeyboardVisibility(listener) {
       return eventBridge.subscribe(event => {
         if (event.type === 'org.racehorse.KeyboardVisibilityChangedAlertEvent') {
-          listener(event.keyboardVisible);
+          listener(event.isKeyboardVisible);
         }
       });
     },

--- a/web/racehorse/src/main/createNetworkManager.ts
+++ b/web/racehorse/src/main/createNetworkManager.ts
@@ -6,7 +6,7 @@ export interface NetworkManager {
   /**
    * The current online status, or `undefined` if not yet known.
    */
-  readonly online: boolean | undefined;
+  readonly isOnline: boolean | undefined;
 
   /**
    * Subscribes to network status changes.
@@ -31,20 +31,20 @@ export function createNetworkManager(eventBridge: EventBridge): NetworkManager {
     }
 
     eventBridge.request({ type: 'org.racehorse.IsOnlineRequestEvent' }).then(event => {
-      online = ensureEvent(event).online;
+      online = ensureEvent(event).isOnline;
       pubSub.publish();
     });
 
     unsubscribe = eventBridge.subscribe(event => {
       if (event.type === 'org.racehorse.OnlineStatusChangedAlertEvent') {
-        online = event.online;
+        online = event.isOnline;
         pubSub.publish();
       }
     });
   };
 
   const manager: NetworkManager = {
-    online: undefined,
+    isOnline: undefined,
 
     subscribe(listener) {
       ensureSubscription();
@@ -52,7 +52,7 @@ export function createNetworkManager(eventBridge: EventBridge): NetworkManager {
     },
   };
 
-  Object.defineProperty(manager, 'online', {
+  Object.defineProperty(manager, 'isOnline', {
     get() {
       ensureSubscription();
       return online;

--- a/web/racehorse/src/main/createNetworkManager.ts
+++ b/web/racehorse/src/main/createNetworkManager.ts
@@ -11,7 +11,7 @@ export interface NetworkManager {
   /**
    * Subscribes to network status changes.
    */
-  subscribe(listener: () => void): () => void;
+  subscribeToOnlineStatusChanges(listener: () => void): () => void;
 }
 
 /**
@@ -46,7 +46,7 @@ export function createNetworkManager(eventBridge: EventBridge): NetworkManager {
   const manager: NetworkManager = {
     isOnline: undefined,
 
-    subscribe(listener) {
+    subscribeToOnlineStatusChanges(listener) {
       ensureSubscription();
       return pubSub.subscribe(listener);
     },

--- a/web/racehorse/src/test/createActionsManager.test.ts
+++ b/web/racehorse/src/test/createActionsManager.test.ts
@@ -4,7 +4,7 @@ describe('createActionsManager', () => {
   test('returns true if opened', async () => {
     const connection: Connection = {
       post: jest.fn(() => {
-        setTimeout(() => connection.inbox!.publish([111, { type: '', ok: true, opened: true }]), 0);
+        setTimeout(() => connection.inbox!.publish([111, { type: '', ok: true, isOpened: true }]), 0);
         return 111;
       }),
     };
@@ -25,7 +25,7 @@ describe('createActionsManager', () => {
   test('returns false if not opened', async () => {
     const connection: Connection = {
       post: jest.fn(() => {
-        setTimeout(() => connection.inbox!.publish([111, { type: '', ok: true, opened: false }]), 0);
+        setTimeout(() => connection.inbox!.publish([111, { type: '', ok: true, isOpened: false }]), 0);
         return 111;
       }),
     };

--- a/web/racehorse/src/test/createNetworkManager.test.ts
+++ b/web/racehorse/src/test/createNetworkManager.test.ts
@@ -5,14 +5,14 @@ describe('createNetworkManager', () => {
   test('returns undefined if network status is unknown', () => {
     const eventBridge = createEventBridge(() => undefined);
 
-    expect(createNetworkManager(eventBridge).online).toBe(undefined);
+    expect(createNetworkManager(eventBridge).isOnline).toBe(undefined);
   });
 
   test('reads initial online status', async () => {
     const connection: Connection = {
       post: jest.fn(() => {
         setTimeout(() => {
-          connection.inbox!.publish([111, { type: '', ok: true, online: true }]);
+          connection.inbox!.publish([111, { type: '', ok: true, isOnline: true }]);
         }, 0);
 
         return 111;
@@ -24,11 +24,11 @@ describe('createNetworkManager', () => {
 
     const networkManager = createNetworkManager(eventBridge);
 
-    expect(networkManager.online).toBe(undefined);
+    expect(networkManager.isOnline).toBe(undefined);
 
     await sleep(100);
 
-    expect(networkManager.online).toBe(true);
+    expect(networkManager.isOnline).toBe(true);
   });
 
   test('calls listener if a network alert arrives', async () => {
@@ -45,10 +45,10 @@ describe('createNetworkManager', () => {
 
     networkManager.subscribe(listenerMock);
 
-    connection.inbox!.publish([-1, { type: 'org.racehorse.OnlineStatusChangedAlertEvent', online: true }]);
+    connection.inbox!.publish([-1, { type: 'org.racehorse.OnlineStatusChangedAlertEvent', isOnline: true }]);
 
     expect(listenerMock).toHaveBeenCalledTimes(1);
 
-    expect(networkManager.online).toBe(true);
+    expect(networkManager.isOnline).toBe(true);
   });
 });

--- a/web/racehorse/src/test/createNetworkManager.test.ts
+++ b/web/racehorse/src/test/createNetworkManager.test.ts
@@ -43,7 +43,7 @@ describe('createNetworkManager', () => {
 
     const networkManager = createNetworkManager(eventBridge);
 
-    networkManager.subscribe(listenerMock);
+    networkManager.subscribeToOnlineStatusChanges(listenerMock);
 
     connection.inbox!.publish([-1, { type: 'org.racehorse.OnlineStatusChangedAlertEvent', isOnline: true }]);
 

--- a/web/react/src/main/useOnline.ts
+++ b/web/react/src/main/useOnline.ts
@@ -17,7 +17,7 @@ export function useOnline(): boolean | undefined {
 
   const [online, setOnline] = useState<boolean>();
 
-  useEffect(() => manager.subscribe(() => setOnline(manager.online)), [manager]);
+  useEffect(() => manager.subscribe(() => setOnline(manager.isOnline)), [manager]);
 
   return online;
 }

--- a/web/react/src/main/useOnline.ts
+++ b/web/react/src/main/useOnline.ts
@@ -17,7 +17,7 @@ export function useOnline(): boolean | undefined {
 
   const [online, setOnline] = useState<boolean>();
 
-  useEffect(() => manager.subscribe(() => setOnline(manager.isOnline)), [manager]);
+  useEffect(() => manager.subscribeToOnlineStatusChanges(() => setOnline(manager.isOnline)), [manager]);
 
   return online;
 }

--- a/web/react/src/test/useOnline.test.ts
+++ b/web/react/src/test/useOnline.test.ts
@@ -14,7 +14,7 @@ describe('useOnline', () => {
   test('reads initial online status', async () => {
     const connection: Connection = {
       post: jest.fn(() => {
-        setTimeout(() => connection.inbox!.publish([111, { type: '', ok: true, online: true }]), 0);
+        setTimeout(() => connection.inbox!.publish([111, { type: '', ok: true, isOnline: true }]), 0);
         return 111;
       }),
     };
@@ -53,7 +53,7 @@ describe('useOnline', () => {
     });
 
     act(() => {
-      connection.inbox!.publish([-1, { type: 'org.racehorse.OnlineStatusChangedAlertEvent', online: true }]);
+      connection.inbox!.publish([-1, { type: 'org.racehorse.OnlineStatusChangedAlertEvent', isOnline: true }]);
     });
 
     expect(hookMock).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
- Renamed `AppWebView.start` to `AppWebView.loadApp`;
- Added `AppWebView.startPlugins` and `AppWebView.pausePlugins`;
- Prefer `is*` notation for boolean fields;
- Fixed window instest acquisition;
- Added `KeyboardVisibilityChangedAlertEvent` to which clients can subscribe using `configurationManager.subscribeToKeyboardVisibility()`;
- Online status is derived from the default network;
- `NetworkPlugin` starts and stops provided `NetworkMonitor`;
- Added `AppWebView.isAppLoaded`.