### PR TITLE
Apply update event

### DIFF
--- a/android/racehorse/src/main/java/org/racehorse/evergreen/Bootstrapper.kt
+++ b/android/racehorse/src/main/java/org/racehorse/evergreen/Bootstrapper.kt
@@ -101,7 +101,7 @@ open class Bootstrapper(private val bundlesDir: File) {
 
         if (isUpdateReady && updateVersion == version) {
             if (!isMasterReady || updateMode != UpdateMode.POSTPONED) {
-                moveUpdateToMaster()
+                applyUpdate()
             }
             onBundleReady(masterDir)
             return
@@ -137,16 +137,25 @@ open class Bootstrapper(private val bundlesDir: File) {
         if (isMasterReady && updateMode != UpdateMode.MANDATORY) {
             onUpdateReady(version)
         } else {
-            moveUpdateToMaster()
+            applyUpdate()
             onBundleReady(masterDir)
         }
     }
 
-    private fun moveUpdateToMaster() {
+    /**
+     * Applies the available update bundle to master.
+     */
+    fun applyUpdate(): Boolean {
+        if (!isUpdateReady) {
+            return false
+        }
+
         masterVersionFile.delete()
         masterDir.deleteRecursively()
 
         updateDir.renameTo(masterDir)
         updateVersionFile.renameTo(masterVersionFile)
+
+        return true
     }
 }

--- a/android/racehorse/src/main/java/org/racehorse/evergreen/BundleDownload.kt
+++ b/android/racehorse/src/main/java/org/racehorse/evergreen/BundleDownload.kt
@@ -10,7 +10,14 @@ import java.util.zip.ZipInputStream
 /**
  * Downloads ZIP archive through the [connection] and extracts its contents to [targetDir].
  *
- * [targetDir] is created only after all operations have been completed and archive contents are ready to be consumed.
+ * - [targetDir] is _always_ deleted when [start] is called.
+ * - [targetDir] is created only after all operations have been completed and archive contents are ready to be consumed.
+ * - If there are temporary artifacts from the previous download, then the download is resumed.
+ *
+ * @param connection The connection from which ZIP archive bytes are read.
+ * @param targetDir The directory to which contents of the ZIP archive are written.
+ * @param bufferSize The size of the buffer into which data is read from the [connection] stream.
+ * @param onProgress The callback that reports progress of the download.
  */
 internal class BundleDownload(
     private val connection: URLConnection,
@@ -19,8 +26,19 @@ internal class BundleDownload(
     private val onProgress: (contentLength: Int, readLength: Long) -> Unit,
 ) {
 
-    private val outputDir = File("$targetDir.output")
+    /**
+     * The directory to which archive contents are unzipped.
+     */
+    private val unzipDir = File("$targetDir.unzip")
+
+    /**
+     * The file with the ETag of the [zipFile] that is being downloaded.
+     */
     private val etagFile = File("$targetDir.etag")
+
+    /**
+     * The file that is being downloaded.
+     */
     private val zipFile = File("$targetDir.zip")
 
     private var isPending = false
@@ -28,8 +46,6 @@ internal class BundleDownload(
 
     /**
      * Starts the download.
-     * - If [targetDir] exists it is removed and download is restarted from scratch.
-     * - If there are temporary artifacts from the previous download, then the download is resumed.
      *
      * @throws IllegalStateException If the download cannot be started after it was stopped, or because it was started
      * before.
@@ -42,8 +58,8 @@ internal class BundleDownload(
 
         targetDir.deleteRecursively()
 
-        outputDir.deleteRecursively()
-        outputDir.mkdirs()
+        unzipDir.deleteRecursively()
+        unzipDir.mkdirs()
 
         download()
 
@@ -53,7 +69,7 @@ internal class BundleDownload(
         if (!isStopped) {
             zipFile.delete()
             etagFile.delete()
-            outputDir.renameTo(targetDir)
+            unzipDir.renameTo(targetDir)
         }
     }
 
@@ -108,15 +124,15 @@ internal class BundleDownload(
     }
 
     private fun unzip() {
-        val unzipDirPath = outputDir.canonicalPath + File.separator
+        val unzipDirPath = unzipDir.canonicalPath + File.separator
 
         ZipInputStream(zipFile.inputStream()).use { inputStream ->
             while (!isStopped) {
-                val file = File(outputDir, inputStream.nextEntry?.name ?: break)
+                val file = File(unzipDir, inputStream.nextEntry?.name ?: break)
 
                 // https://snyk.io/research/zip-slip-vulnerability
                 if (file.canonicalPath.startsWith(unzipDirPath)) {
-                    file.parentFile?.mkdirs()
+                    file.parentFile!!.mkdirs()
                     inputStream.copyTo(FileOutputStream(file))
                 }
 

--- a/web/racehorse/src/main/createEvergreenManager.ts
+++ b/web/racehorse/src/main/createEvergreenManager.ts
@@ -23,10 +23,15 @@ export interface EvergreenManager {
    * Get the version of the update that would be applied on the next app restart.
    */
   getUpdateStatus(): Promise<UpdateStatus | null>;
+
+  /**
+   * Applies the available update bundle and returns its version, or returns `null` if there's no update available.
+   */
+  applyUpdate(): Promise<string | null>;
 }
 
 /**
- * Retrieves bundle versions and update status.
+ * Handles background updates.
  *
  * @param eventBridge The underlying event bridge.
  */
@@ -41,5 +46,10 @@ export function createEvergreenManager(eventBridge: EventBridge): EvergreenManag
       eventBridge
         .request({ type: 'org.racehorse.evergreen.GetUpdateStatusRequestEvent' })
         .then(event => ensureEvent(event).status),
+
+    applyUpdate: () =>
+      eventBridge
+        .request({ type: 'org.racehorse.evergreen.ApplyUpdateRequestEvent' })
+        .then(event => ensureEvent(event).version),
   };
 }

--- a/web/racehorse/src/main/createGooglePlayReferrerManager.ts
+++ b/web/racehorse/src/main/createGooglePlayReferrerManager.ts
@@ -17,9 +17,6 @@ export function createGooglePlayReferrerManager(eventBridge: EventBridge): Googl
     getGooglePlayReferrer: () =>
       (referrerPromise ||= eventBridge
         .request({ type: 'org.racehorse.GetGooglePlayReferrerRequestEvent' })
-        .then(event => {
-          referrerPromise = undefined;
-          return ensureEvent(event).referrer;
-        })),
+        .then(event => ensureEvent(event).referrer)),
   };
 }


### PR DESCRIPTION
Added `evergreenManager.applyUpdate()` that moves the available update bundle to master and returns the new master version, or returns `null` if no update is available.