### PR TITLE
Evicted QUERY_ALL_PACKAGES permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,178 @@
 # Racehorse 🏇
 
+The bootstrapper for `WebView`-based Android apps.
+
+# Basics
+
+Racehorse is the pluggable bridge that marshals events between the web app and the native Android app. To showcase how
+Racehorse works, let's create a plugin that would display
+[an Android-native toast](https://developer.android.com/guide/topics/ui/notifiers/toasts) when the web app requests it.
+
+Let's start by creating the `WebView`:
+
+```kotlin
+import android.webkit.WebView
+
+val webView = WebView(activityOrContext)
+// or
+// val webView = activity.findViewById<WebView>(R.id.web_view)
+```
+
+Create an `EventBridge` instance that would be responsible for event marshalling:
+
+```kotlin
+import org.racehorse.EventBridge
+
+val eventBridge = EventBridge(webView)
+```
+
+Racehorse uses an [event bus](https://greenrobot.org/eventbus) to deliver events to subscribers, so bridge must be
+registered in the event bus:
+
+```kotlin
+import org.greenrobot.eventbus.EventBus
+
+EventBus.getDefault().register(eventBridge)
+```
+
+Here's an event that is posted from the web to Android through the bridge:
+
+```kotlin
+package com.example
+
+import org.racehorse.WebEvent
+
+class ShowToastEvent(val message: String) : WebEvent
+```
+
+Note that `ShowToastEvent` implements `WebEvent` marker interface. This is the baseline requirement to which events 
+must conform to support marshalling from the web app to Android.
+
+Now let's add an event subscriber that would receive incoming `ShowToastEvent` and display a toast:
+
+```kotlin
+package com.example
+
+import android.content.Context
+import android.widget.Toast
+import org.greenrobot.eventbus.Subscribe
+
+class ToastPlugin(val context: Context) {
+
+    @Subscribe
+    fun onShowToast(event: ShowToastEvent) {
+        Toast.makeText(context, event.message, Toast.LENGTH_SHORT).show()
+    }
+}
+```
+
+To enable `ToastPlugin` plugin, it should be registered in the event bus as well:
+
+```kotlin
+EventBus.getDefault().register(ToastPlugin(activityOrContext))
+```
+
+Now the native part is set up, and we can send an event from the web app:
+
+```js
+import { eventBridge } from 'racehorse';
+
+eventBridge.request({
+  // 🟡 The event class name
+  type: 'com.example.ShowToastEvent',
+  message: 'Hello, world!'
+});
+```
+
+The last step is to load the web app into the `webView`. You can do this in any way that fits your needs, Racehorse
+doesn't restrict this process in any way. For example, if your web app is running on your local machine on the port
+1234, then you can load the web app in the web view using this snippet: 
+
+```kotlin
+webView.loadUrl("https://10.0.2.2:1234")
+```
+
+# Request-response event chains
+
+In the [Basics](#basics) section we used an event that extends a `WebEvent` interface. Such events don't imply the
+response. To create a request-response chain at least two events are required:
+
+```kotlin
+package com.example
+
+import android.os.Build
+import org.greenrobot.eventbus.Subscribe
+import org.racehorse.RequestEvent
+import org.racehorse.ResponseEvent
+import org.racehorse.utils.postToChain
+
+class GetDeviceModelRequestEvent : RequestEvent()
+
+class GetDeviceModelResponseEvent(val deviceModel: String) : ResponseEvent()
+
+class DeviceModelPlugin {
+
+    @Subscribe
+    fun onGetDeviceModel(event: GetDeviceModelRequestEvent) {
+        EventBus.getDefault().postToChain(
+            event,
+            GetDeviceModelResponseEvent(Build.MODEL)
+        )
+    }
+}
+```
+
+Request and response events are instances of `ChainableEvent`. Events in the chain share the same `requestId`. When a
+`ResponseEvent` is posted to the event bus it is marshalled to the web app and resolves a promise returned from the
+`eventBridge.request`:
+
+```ts
+import { eventBridge } from 'racehorse';
+
+const deviceModel = await eventBridge
+  .request({ type: 'com.example.GetDeviceModelRequestEvent' })
+  .then(event => event.deviceModel)
+```
+
+If an exception is thrown in `DeviceModelPlugin.onGetDeviceModel`, then promise is _resolved_ with
+`org.racehorse.ExceptionEvent`.
+
+# Event subscriptions in the web app
+
+While web can post a request event to the Android, it is frequently required that the Android would post an event to the
+web app without an explicit request. This can be achieved using subscriptions.
+
+Let's define an event that the Android can post to the web:
+
+```kotlin
+package com.example
+
+import org.racehorse.NoticeEvent
+
+class BatteryLowEvent : NoticeEvent
+```
+
+To receive this event in the web app, add a listener:
+
+```js
+import { eventBridge } from 'racehorse';
+
+eventBridge.subscribe(event => {
+  if (event.type === 'com.example.BatteryLowEvent') {
+    // Handle the event here
+  }
+})
+```
+
+If you have [an `EventBridge` registered](#basics) in the event bus, then you can post `BatteryLowEvent` event from
+anywhere in your Android app, and it would be delivered to a subscriber in the web app:
+
+```kotlin
+EventBus.getDefault().post(BatteryLowEvent())
+```
+
+# Evergreen
+
 ```mermaid
 graph TD
 

--- a/android/example/src/androidTest/java/com/example/myapplication/ExampleInstrumentedTest.kt
+++ b/android/example/src/androidTest/java/com/example/myapplication/ExampleInstrumentedTest.kt
@@ -1,12 +1,10 @@
 package com.example.myapplication
 
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
-
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
-
-import org.junit.Assert.*
 
 /**
  * Instrumented test, which will execute on an Android device.

--- a/android/example/src/test/java/com/example/myapplication/ExampleUnitTest.kt
+++ b/android/example/src/test/java/com/example/myapplication/ExampleUnitTest.kt
@@ -1,8 +1,7 @@
 package com.example.myapplication
 
+import org.junit.Assert.assertEquals
 import org.junit.Test
-
-import org.junit.Assert.*
 
 /**
  * Example local unit test, which will execute on the development machine (host).

--- a/android/racehorse/src/androidTest/java/org/racehorse/ExampleInstrumentedTest.kt
+++ b/android/racehorse/src/androidTest/java/org/racehorse/ExampleInstrumentedTest.kt
@@ -1,12 +1,10 @@
 package org.racehorse
 
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
-
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.*
 import org.junit.Test
 import org.junit.runner.RunWith
-
-import org.junit.Assert.*
 
 /**
  * Instrumented test, which will execute on an Android device.

--- a/android/racehorse/src/main/AndroidManifest.xml
+++ b/android/racehorse/src/main/AndroidManifest.xml
@@ -1,14 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- Required by org.racehorse.NetworkPlugin -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
-    <!-- Required by org.racehorse.Intents.excludePackages -->
-    <uses-permission
-        android:name="android.permission.QUERY_ALL_PACKAGES"
-        tools:ignore="QueryAllPackagesPermission" />
     <queries>
         <intent>
             <action android:name="android.intent.action.VIEW" />

--- a/android/racehorse/src/main/java/org/racehorse/DeepLinkPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/DeepLinkPlugin.kt
@@ -2,9 +2,6 @@ package org.racehorse
 
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
-import org.racehorse.NoticeEvent
-import org.racehorse.RequestEvent
-import org.racehorse.ResponseEvent
 import org.racehorse.utils.postToChain
 
 /**

--- a/android/racehorse/src/main/java/org/racehorse/EventBridge.kt
+++ b/android/racehorse/src/main/java/org/racehorse/EventBridge.kt
@@ -47,10 +47,8 @@ abstract class RequestEvent : ChainableEvent(), WebEvent
 
 /**
  * An event that is published to the web, denoting an end of a request.
- *
- * @param ok Indicates that the response is successful or not.
  */
-abstract class ResponseEvent(val ok: Boolean = true) : ChainableEvent()
+abstract class ResponseEvent : ChainableEvent()
 
 /**
  * Response with no payload.
@@ -60,7 +58,7 @@ class VoidEvent : ResponseEvent()
 /**
  * Response that describes an occurred exception.
  */
-class ExceptionEvent(@Transient val cause: Throwable) : ResponseEvent(false) {
+class ExceptionEvent(@Transient val cause: Throwable) : ResponseEvent() {
     val stackTrace = cause.stackTraceToString()
 }
 

--- a/android/racehorse/src/main/java/org/racehorse/utils/Activities.kt
+++ b/android/racehorse/src/main/java/org/racehorse/utils/Activities.kt
@@ -1,8 +1,6 @@
 package org.racehorse.utils
 
 import android.content.ActivityNotFoundException
-import android.view.View
-import android.view.WindowInsets
 import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultCallback
 import androidx.activity.result.ActivityResultLauncher

--- a/web/example/src/examples/ToastExample.tsx
+++ b/web/example/src/examples/ToastExample.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { eventBridge } from 'racehorse/src/main';
+import { eventBridge } from 'racehorse';
 
 export function ToastExample() {
   const [message, setMessage] = useState('Hello');

--- a/web/racehorse/src/main/createEventBridge.ts
+++ b/web/racehorse/src/main/createEventBridge.ts
@@ -1,5 +1,5 @@
 import { PubSub, untilTruthy } from 'parallel-universe';
-import { Connection, Event, EventBridge, ResponseEvent } from './types';
+import { Connection, Event, EventBridge } from './types';
 
 declare global {
   interface Window {
@@ -49,7 +49,7 @@ export function createEventBridge(connectionProvider = () => window.racehorseCon
             const unsubscribe = connection.inbox.subscribe(envelope => {
               if (envelope[0] === requestId) {
                 unsubscribe();
-                resolve(envelope[1] as ResponseEvent);
+                resolve(envelope[1]);
               }
             });
           })

--- a/web/racehorse/src/main/types.ts
+++ b/web/racehorse/src/main/types.ts
@@ -16,16 +16,6 @@ export interface Event {
 }
 
 /**
- * The response event pushed by Android as the result of a request.
- */
-export interface ResponseEvent extends Event {
-  /**
-   * `true` for a success response, or `false` for an error response.
-   */
-  ok: boolean;
-}
-
-/**
  * The connection is added to the page as a
  * [`JavascriptInterface`](https://developer.android.com/reference/android/webkit/JavascriptInterface).
  */
@@ -61,12 +51,11 @@ export interface EventBridge {
   /**
    * Sends an event through a connection to Android and returns a promise that is resolved when a response with a
    * matching ID is published to the {@link Connection.inbox}. The returned promise is never rejected.
-   * Check {@link ResponseEvent.ok} to detect that an error occurred.
    *
    * @param event The request event to send.
    * @returns The response event.
    */
-  request(event: Event): Promise<ResponseEvent>;
+  request(event: Event): Promise<Event>;
 
   /**
    * Subscribes a listener to alert events pushed by Android.

--- a/web/racehorse/src/main/utils.ts
+++ b/web/racehorse/src/main/utils.ts
@@ -1,11 +1,11 @@
-import { ResponseEvent } from './types';
+import { Event } from './types';
 
 /**
  * Throws an error if an event carries an exception, or returns event as is.
  *
  * @param event The event to ensure isn't an exception.
  */
-export function ensureEvent(event: ResponseEvent): ResponseEvent {
+export function ensureEvent(event: Event): Event {
   if (event.type === 'org.racehorse.ExceptionEvent') {
     throw new Error(event.stackTrace);
   }

--- a/web/racehorse/src/test/createEventBridge.test.ts
+++ b/web/racehorse/src/test/createEventBridge.test.ts
@@ -13,7 +13,7 @@ describe('createEventBridge', () => {
     provideConnection = () => {
       connectionMock = {
         post: jest.fn(() => {
-          setTimeout(() => connectionMock!.inbox!.publish([111, { type: 'bbb', ok: true }]), 0);
+          setTimeout(() => connectionMock!.inbox!.publish([111, { type: 'bbb' }]), 0);
           return 111;
         }),
       };
@@ -30,7 +30,7 @@ describe('createEventBridge', () => {
     provideConnection();
     const eventBridge = createEventBridge(connectionProviderMock);
 
-    await expect(eventBridge.request({ type: 'aaa' })).resolves.toEqual({ type: 'bbb', ok: true });
+    await expect(eventBridge.request({ type: 'aaa' })).resolves.toEqual({ type: 'bbb' });
 
     expect(connectionMock!.post).toHaveBeenCalledTimes(1);
     expect(connectionMock!.post).toHaveBeenNthCalledWith(1, '{"type":"aaa"}');
@@ -43,7 +43,7 @@ describe('createEventBridge', () => {
 
     setTimeout(provideConnection, 100);
 
-    await expect(promise).resolves.toEqual({ type: 'bbb', ok: true });
+    await expect(promise).resolves.toEqual({ type: 'bbb' });
 
     expect(connectionMock!.post).toHaveBeenCalledTimes(1);
     expect(connectionMock!.post).toHaveBeenNthCalledWith(1, '{"type":"aaa"}');
@@ -86,11 +86,11 @@ describe('createEventBridge', () => {
     connectionMock!.post = jest
       .fn()
       .mockImplementationOnce(() => {
-        setTimeout(() => connectionMock!.inbox!.publish([111, { type: 'bbb', ok: true }]), 0);
+        setTimeout(() => connectionMock!.inbox!.publish([111, { type: 'bbb' }]), 0);
         return 111;
       })
       .mockImplementationOnce(() => {
-        setTimeout(() => connectionMock!.inbox!.publish([222, { type: 'bbb', ok: true }]), 0);
+        setTimeout(() => connectionMock!.inbox!.publish([222, { type: 'bbb' }]), 0);
         return 222;
       });
 
@@ -98,12 +98,12 @@ describe('createEventBridge', () => {
 
     await eventBridge1.connect();
 
-    await expect(eventBridge1.request({ type: 'aaa' })).resolves.toEqual({ type: 'bbb', ok: true });
+    await expect(eventBridge1.request({ type: 'aaa' })).resolves.toEqual({ type: 'bbb' });
 
     const eventBridge2 = createEventBridge(connectionProviderMock);
 
     await eventBridge2.connect();
 
-    await expect(eventBridge2.request({ type: 'aaa' })).resolves.toEqual({ type: 'bbb', ok: true });
+    await expect(eventBridge2.request({ type: 'aaa' })).resolves.toEqual({ type: 'bbb' });
   });
 });


### PR DESCRIPTION
- `Intent.excludePackages` is now optional, since it requires a sensitive permission `android.permission.QUERY_ALL_PACKAGES` which seems to be overkill when applied by default;
- Removed `ResponseEvent` from the web;
- Added basic docs.