### PR TITLE
Fixed network race condition

### DIFF
--- a/android/racehorse/src/main/java/org/racehorse/NetworkPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/NetworkPlugin.kt
@@ -50,11 +50,8 @@ open class NetworkPlugin(private val context: Context, private val eventBus: Eve
 
     private val networkCallback = object : ConnectivityManager.NetworkCallback() {
 
-        override fun onAvailable(network: Network) =
-            handleChange(capabilities)
-
         override fun onLost(network: Network) =
-            handleChange(capabilities)
+            handleChange(null)
 
         override fun onCapabilitiesChanged(network: Network, capabilities: NetworkCapabilities) =
             handleChange(capabilities)


### PR DESCRIPTION
Removed race condition caused by [capabilities access from `onAvailable` method.](https://developer.android.com/reference/android/net/ConnectivityManager.NetworkCallback#onAvailable(android.net.Network))