### PR TITLE
Built-in ProGuard rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,3 +212,9 @@ IsUpdateSameVersionAsNext
 DownloadBundle
 --> BundleDownloaded
 ```
+
+# Proguard
+
+`org.racehorse:racehorse` is an Android library (AAR) that provides its own
+[proguard rules](./android/racehorse/proguard-rules.pro), so no additional action is needed. Proguard rules prevent
+obfuscation of events and related classes which are available in Racehorse. 

--- a/android/racehorse/build.gradle.kts
+++ b/android/racehorse/build.gradle.kts
@@ -19,13 +19,13 @@ android {
         targetSdk = 33
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles("consumer-rules.pro")
+
+        consumerProguardFiles("proguard-rules.pro")
     }
 
     buildTypes {
         release {
             isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
         create("staging") {
             initWith(getByName("debug"))

--- a/android/racehorse/proguard-rules.pro
+++ b/android/racehorse/proguard-rules.pro
@@ -1,21 +1,7 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+-keepnames class org.racehorse.** extends java.io.Serializable { *; }
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+-keepclassmembers class org.racehorse.** extends java.io.Serializable { *; }
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
-
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+-keepclassmembers class ** {
+    @android.webkit.JavascriptInterface <methods>;
+}

--- a/android/racehorse/proguard-rules.pro
+++ b/android/racehorse/proguard-rules.pro
@@ -2,6 +2,6 @@
 
 -keepclassmembers class org.racehorse.** extends java.io.Serializable { *; }
 
--keepclassmembers class ** {
+-keepclassmembers class org.racehorse.** {
     @android.webkit.JavascriptInterface <methods>;
 }

--- a/android/racehorse/src/main/java/org/racehorse/ActivityPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/ActivityPlugin.kt
@@ -8,8 +8,9 @@ import org.racehorse.utils.WebIntent
 import org.racehorse.utils.launchActivity
 import org.racehorse.utils.launchActivityForResult
 import org.racehorse.utils.postToChain
+import java.io.Serializable
 
-class ActivityInfo(val packageName: String)
+class ActivityInfo(val packageName: String) : Serializable
 
 class GetActivityInfoEvent : RequestEvent() {
     class ResultEvent(val activityInfo: ActivityInfo) : ResponseEvent()

--- a/android/racehorse/src/main/java/org/racehorse/DevicePlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/DevicePlugin.kt
@@ -7,10 +7,11 @@ import androidx.core.view.WindowInsetsCompat.toWindowInsetsCompat
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.racehorse.utils.postToChain
+import java.io.Serializable
 
-class DeviceInfo(val apiLevel: Int, val brand: String, val model: String)
+class DeviceInfo(val apiLevel: Int, val brand: String, val model: String) : Serializable
 
-class Rect(val top: Float, val right: Float, val bottom: Float, val left: Float)
+class Rect(val top: Float, val right: Float, val bottom: Float, val left: Float) : Serializable
 
 /**
  * Get OS and device versions.

--- a/android/racehorse/src/main/java/org/racehorse/EventBridge.kt
+++ b/android/racehorse/src/main/java/org/racehorse/EventBridge.kt
@@ -18,12 +18,12 @@ import java.util.concurrent.atomic.AtomicInteger
 /**
  * An event posted from the web view. Only events that implement this interface are "visible" to the web application.
  */
-interface WebEvent
+interface WebEvent : Serializable
 
 /**
  * An event published by Android for subscribers in web view.
  */
-interface NoticeEvent
+interface NoticeEvent : Serializable
 
 /**
  * An event that is the part of request-response chain of events.
@@ -54,7 +54,7 @@ abstract class RequestEvent : ChainableEvent(), WebEvent
 /**
  * An event that is published to the web, denoting an end of a request.
  */
-abstract class ResponseEvent : ChainableEvent()
+abstract class ResponseEvent : ChainableEvent(), Serializable
 
 /**
  * Response with no payload. Use this event to commit the chain of events that doesn't imply a response. Chain of events

--- a/android/racehorse/src/main/java/org/racehorse/NetworkPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/NetworkPlugin.kt
@@ -8,6 +8,7 @@ import com.google.gson.annotations.SerializedName
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.racehorse.utils.postToChain
+import java.io.Serializable
 
 class GetNetworkStatusEvent : RequestEvent() {
     class ResultEvent(val status: NetworkStatus) : ResponseEvent()
@@ -15,7 +16,7 @@ class GetNetworkStatusEvent : RequestEvent() {
 
 class NetworkStatusChangedEvent(val status: NetworkStatus) : NoticeEvent
 
-data class NetworkStatus(val type: NetworkType, val isConnected: Boolean)
+data class NetworkStatus(val type: NetworkType, val isConnected: Boolean) : Serializable
 
 enum class NetworkType {
     @SerializedName("wifi")

--- a/android/racehorse/src/main/java/org/racehorse/evergreen/EvergreenPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/evergreen/EvergreenPlugin.kt
@@ -8,6 +8,7 @@ import org.racehorse.RequestEvent
 import org.racehorse.ResponseEvent
 import org.racehorse.utils.postToChain
 import java.io.File
+import java.io.Serializable
 
 /**
  * The status of the update bundle.
@@ -16,12 +17,12 @@ import java.io.File
  * @param isReady `true` if the update is fully downloaded and ready to be applied, or `false` if update is being
  * downloaded.
  */
-class UpdateStatus(val version: String, val isReady: Boolean)
+class UpdateStatus(val version: String, val isReady: Boolean) : Serializable
 
 /**
  * App assets available in [appDir] and are ready to be used.
  */
-class BundleReadyEvent(val appDir: File) : NoticeEvent
+class BundleReadyEvent(@Transient val appDir: File) : NoticeEvent
 
 /**
  * The new update download has started.

--- a/android/racehorse/src/main/java/org/racehorse/utils/NaturalAdapter.kt
+++ b/android/racehorse/src/main/java/org/racehorse/utils/NaturalAdapter.kt
@@ -65,7 +65,10 @@ class NaturalAdapter : JsonDeserializer<Any?>, JsonSerializer<Any?> {
 
         is Map<*, *> -> serializeObject(src.toList(), context)
 
-        is Bundle -> serializeObject(src.keySet().map { it to src.get(it) }, context)
+        is Bundle -> serializeObject(src.keySet().map {
+            @Suppress("DEPRECATION")
+            it to src.get(it)
+        }, context)
 
         else -> null
     }

--- a/android/racehorse/src/main/java/org/racehorse/utils/WebIntent.kt
+++ b/android/racehorse/src/main/java/org/racehorse/utils/WebIntent.kt
@@ -19,7 +19,7 @@ class WebIntent(
     var data: String? = null,
     var flags: Int = 0,
     var extras: Map<String, Serializable?>? = null
-) {
+) : Serializable {
 
     @Suppress("DEPRECATION")
     constructor(intent: Intent) : this(


### PR DESCRIPTION
- Events and related classes are marked as `java.io.Serializable`;
- Added ProGuard rules that prevent obfuscation of Racehorse events.