### PR TITLE
Filter intent tragets by package names

### DIFF
--- a/android/racehorse/src/main/java/org/racehorse/FileChooserPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/FileChooserPlugin.kt
@@ -53,8 +53,8 @@ private class FileChooserLauncher(
 
     private val mimeTypes = fileChooserParams.acceptTypes.joinToString(",")
 
-    private val isImage = mimeTypes.isEmpty() || mimeTypes.contains("*/*") || mimeTypes.contains("image/")
-    private val isVideo = mimeTypes.isEmpty() || mimeTypes.contains("*/*") || mimeTypes.contains("video/")
+    private val isImage = mimeTypes.isEmpty() || "*/*" in mimeTypes || "image/" in mimeTypes
+    private val isVideo = mimeTypes.isEmpty() || "*/*" in mimeTypes || "video/" in mimeTypes
 
     fun start() {
         if (

--- a/android/racehorse/src/main/java/org/racehorse/PermissionsPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/PermissionsPlugin.kt
@@ -51,10 +51,10 @@ open class PermissionsPlugin(private val activity: ComponentActivity) {
     open fun onPermissionRequest(event: PermissionRequestEvent) {
         val permissions = HashSet<String>()
 
-        if (event.request.resources.contains(PermissionRequest.RESOURCE_VIDEO_CAPTURE)) {
+        if (PermissionRequest.RESOURCE_VIDEO_CAPTURE in event.request.resources) {
             permissions.add(Manifest.permission.CAMERA)
         }
-        if (event.request.resources.contains(PermissionRequest.RESOURCE_AUDIO_CAPTURE)) {
+        if (PermissionRequest.RESOURCE_AUDIO_CAPTURE in event.request.resources) {
             permissions.add(Manifest.permission.RECORD_AUDIO)
         }
         if (permissions.isEmpty() || !event.shouldHandle()) {

--- a/android/racehorse/src/main/java/org/racehorse/utils/Intents.kt
+++ b/android/racehorse/src/main/java/org/racehorse/utils/Intents.kt
@@ -6,7 +6,7 @@ import android.net.Uri
 import android.os.Build
 
 /**
- * Returns the new intent that is applied only to packages that passed the filter.
+ * Returns the new intent that is applied only to packages that are accepted by the predicate.
  *
  * For example, to prevent sharing a URL via Bluetooth:
  *


### PR DESCRIPTION
`Intent.filterPackageNames` returns the new intent that is applied only to packages that are accepted by the predicate.

For example, to prevent sharing a URL via Bluetooth:

```kotlin
val intent = Intent(Intent.ACTION_SEND)
    .setType("text/plain")
    .putExtra(Intent.EXTRA_TEXT, "http://example.com")
    .filterPackageNames(activity.packageManager) { "bluetooth" !in it }
```

Add query to the manifest:

```xml
<manifest>
  <queries>
    <intent>
      <action android:name="android.intent.action.SEND" />
      <data android:mimeType="text/plain" />
    </intent>
  </queries>
</manifest>
```