### PR TITLE
Keyboard visibility toggling

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,7 +889,7 @@ EventBus.getDefault().register(KeyboardPlugin(activity))
 ```ts
 import { keyboardManager } from 'racehorse';
 
-keyboardManager.getStatus().isVisible;
+keyboardManager.getKeyboardStatus().isVisible;
 // ⮕ true
 
 keyboardManager.subscribe(status => {
@@ -931,7 +931,7 @@ EventBus.getDefault().register(NetworkPlugin(activity))
 ```ts
 import { networkManager } from 'racehorse';
 
-networkManager.getStatus().isConnected;
+networkManager.getNetworkStatus().isConnected;
 // ⮕ true
 
 networkManager.subscribe(status => {

--- a/web/racehorse/src/main/createEvergreenManager.ts
+++ b/web/racehorse/src/main/createEvergreenManager.ts
@@ -33,18 +33,18 @@ export interface EvergreenManager {
   /**
    * The new update download has started.
    */
-  subscribe(type: 'started', listener: (payload: { updateMode: UpdateMode }) => void): () => void;
+  subscribe(eventType: 'started', listener: (payload: { updateMode: UpdateMode }) => void): () => void;
 
   /**
    * Failed to download an update.
    */
-  subscribe(type: 'failed', listener: (payload: { updateMode: UpdateMode }) => void): () => void;
+  subscribe(eventType: 'failed', listener: (payload: { updateMode: UpdateMode }) => void): () => void;
 
   /**
    * An update was successfully downloaded and ready to be applied.
    */
   subscribe(
-    type: 'ready',
+    eventType: 'ready',
     listener: (payload: {
       /**
        * The version of the update bundle that is ready to be applied.
@@ -57,7 +57,7 @@ export interface EvergreenManager {
    * Progress of a pending update download.
    */
   subscribe(
-    type: 'progress',
+    eventType: 'progress',
     listener: (payload: {
       /**
        * The length of downloaded content in bytes, or -1 if content length cannot be detected.
@@ -91,14 +91,14 @@ export function createEvergreenManager(eventBridge: EventBridge): EvergreenManag
         return event.payload.version;
       })),
 
-    subscribe: (type, listener) =>
+    subscribe: (eventType, listener) =>
       eventBridge.subscribe(
         {
           started: 'org.racehorse.UpdateStartedEvent',
           failed: 'org.racehorse.UpdateFailedEvent',
           ready: 'org.racehorse.UpdateReadyEvent',
           progress: 'org.racehorse.UpdateProgressEvent',
-        }[type],
+        }[eventType],
         listener
       ),
   };

--- a/web/racehorse/src/main/createKeyboardManager.ts
+++ b/web/racehorse/src/main/createKeyboardManager.ts
@@ -9,7 +9,19 @@ export interface KeyboardManager {
   /**
    * Returns the status of the software keyboard.
    */
-  getStatus(): KeyboardStatus;
+  getKeyboardStatus(): KeyboardStatus;
+
+  /**
+   * Shows the keyboard.
+   */
+  showKeyboard(): void;
+
+  /**
+   * Hides the keyboard.
+   *
+   * @returns `true` if the keyboard was actually hidden, or `false` otherwise.
+   */
+  hideKeyboard(): boolean;
 
   /**
    * Subscribes a listener to software keyboard status changes.
@@ -19,7 +31,13 @@ export interface KeyboardManager {
 
 export function createKeyboardManager(eventBridge: EventBridge): KeyboardManager {
   return {
-    getStatus: () => eventBridge.request({ type: 'org.racehorse.GetKeyboardStatusEvent' }).payload.status,
+    getKeyboardStatus: () => eventBridge.request({ type: 'org.racehorse.GetKeyboardStatusEvent' }).payload.status,
+
+    showKeyboard() {
+      eventBridge.request({ type: 'org.racehorse.ShowKeyboardEvent' });
+    },
+
+    hideKeyboard: () => eventBridge.request({ type: 'org.racehorse.HideKeyboardEvent' }).payload.isHidden,
 
     subscribe: listener =>
       eventBridge.subscribe('org.racehorse.KeyboardStatusChangedEvent', payload => {

--- a/web/racehorse/src/main/createNetworkManager.ts
+++ b/web/racehorse/src/main/createNetworkManager.ts
@@ -11,7 +11,7 @@ export interface NetworkManager {
   /**
    * Returns the status of the active network.
    */
-  getStatus(): NetworkStatus;
+  getNetworkStatus(): NetworkStatus;
 
   /**
    * Subscribes to network status changes.
@@ -26,7 +26,7 @@ export interface NetworkManager {
  */
 export function createNetworkManager(eventBridge: EventBridge): NetworkManager {
   return {
-    getStatus: () => eventBridge.request({ type: 'org.racehorse.GetNetworkStatusEvent' }).payload.status,
+    getNetworkStatus: () => eventBridge.request({ type: 'org.racehorse.GetNetworkStatusEvent' }).payload.status,
 
     subscribe: listener =>
       eventBridge.subscribe('org.racehorse.NetworkStatusChangedEvent', payload => {

--- a/web/react/src/main/useKeyboardStatus.ts
+++ b/web/react/src/main/useKeyboardStatus.ts
@@ -14,7 +14,7 @@ KeyboardManagerContext.displayName = 'KeyboardManagerContext';
 export function useKeyboardStatus(): KeyboardStatus {
   const manager = useContext(KeyboardManagerContext);
 
-  const [status, setStatus] = useState(manager.getStatus);
+  const [status, setStatus] = useState(manager.getKeyboardStatus);
 
   useEffect(() => manager.subscribe(setStatus), [manager]);
 

--- a/web/react/src/main/useNetworkStatus.ts
+++ b/web/react/src/main/useNetworkStatus.ts
@@ -14,7 +14,7 @@ NetworkManagerContext.displayName = 'NetworkManagerContext';
 export function useNetworkStatus(): NetworkStatus {
   const manager = useContext(NetworkManagerContext);
 
-  const [status, setStatus] = useState(manager.getStatus);
+  const [status, setStatus] = useState(manager.getNetworkStatus);
 
   useEffect(() => manager.subscribe(setStatus), [manager]);
 


### PR DESCRIPTION
- Added `keyboardManager.showKeyboard` and `keyboardManager.hideKeyboard` methods to toggle keyboard visibility;
- Renamed `keyboardManager.getStatus` and `networkManager.getStatus` to `keyboardManager.getKeyboardStatus` and `networkManager.getNetworkStatus` respectively for better readability.