### PR TITLE
Simpler request-response chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ instance that would be responsible for event marshalling:
 import org.racehorse.EventBridge
 
 val eventBridge = EventBridge(webView)
+
+eventBridge.enable()
 ```
 
 Racehorse uses a [Greenrobot EventBus](https://greenrobot.org/eventbus) to deliver events to subscribers, so bridge must

--- a/android/example/src/main/java/com/example/MainActivity.kt
+++ b/android/example/src/main/java/com/example/MainActivity.kt
@@ -27,7 +27,6 @@ class MainActivity : AppCompatActivity() {
     private val webView by lazy { WebView(this) }
     private val eventBus = EventBus.getDefault()
     private val networkPlugin = NetworkPlugin(this)
-    private val lifecyclePlugin = LifecyclePlugin()
     private val cookieManager = CookieManager.getInstance()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -48,7 +47,7 @@ class MainActivity : AppCompatActivity() {
         cookieManager.setAcceptCookie(true)
         cookieManager.setAcceptThirdPartyCookies(webView, true)
 
-        eventBus.register(EventBridge(webView))
+        eventBus.register(EventBridge(webView).apply { enable() })
         eventBus.register(DevicePlugin(this))
         eventBus.register(EncryptedStoragePlugin(File(filesDir, "storage"), BuildConfig.APPLICATION_ID.toByteArray()))
         eventBus.register(FileChooserPlugin(this, externalCacheDir, "${BuildConfig.APPLICATION_ID}.provider"))
@@ -67,10 +66,8 @@ class MainActivity : AppCompatActivity() {
         eventBus.register(FacebookSharePlugin(this))
         eventBus.register(BiometricPlugin(this))
         eventBus.register(BiometricEncryptedStoragePlugin(this, File(filesDir, "biometric_storage")))
-        eventBus.register(lifecyclePlugin)
+        eventBus.register(LifecyclePlugin().apply { enable() })
         eventBus.register(ToastPlugin(this))
-
-        lifecyclePlugin.enable()
 
         @Suppress("DEPRECATION")
         FacebookSdk.sdkInitialize(this)

--- a/android/example/src/main/java/com/example/MainActivity.kt
+++ b/android/example/src/main/java/com/example/MainActivity.kt
@@ -72,7 +72,7 @@ class MainActivity : AppCompatActivity() {
         @Suppress("DEPRECATION")
         FacebookSdk.sdkInitialize(this)
 
-        // Run `npm run watch` in `<racehorse>/web/example` to build the web app and start the server.
+        // 🟡 Run `npm run watch` in `<racehorse>/web/example` to build the web app and start the server.
 
         if (BuildConfig.DEBUG) {
             // 1️⃣ Live reload
@@ -85,8 +85,8 @@ class MainActivity : AppCompatActivity() {
         } else {
             // 2️⃣ Evergreen
             //
-            // An update bundle `web/example/dist/bundle.zip` is downloaded using the `EvergreenPlugin` and served from
-            // the internal app cache.
+            // An update bundle `<racehorse>/web/example/dist/bundle.zip` is downloaded using the `EvergreenPlugin` and
+            // served from the internal app cache.
             //
             // If the bundle is downloaded via a non-secure request, then add `android:usesCleartextTraffic="true"`
             // attribute to `AndroidManifest.xml/manifest/application`. `BundleReadyEvent` is emitted after bundle is
@@ -97,9 +97,10 @@ class MainActivity : AppCompatActivity() {
             eventBus.register(this)
             eventBus.register(evergreenPlugin)
 
+            // Download the bundle in the background thread.
             Thread {
-                // The update bundle is downloaded if there's no bundle available, or if provided version differs from
-                // the version of previously downloaded bundle.
+                // The update bundle is downloaded if there's no bundle available, or if the provided version differs
+                // from the version of previously downloaded bundle.
                 evergreenPlugin.start("0.0.0", UpdateMode.MANDATORY) {
                     URL("http://10.0.2.2:10001/bundle.zip").openConnection()
                 }

--- a/android/racehorse/src/main/java/org/racehorse/DownloadPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/DownloadPlugin.kt
@@ -232,12 +232,12 @@ open class DownloadPlugin(private val activity: ComponentActivity) {
         }
 
         if (Build.VERSION.SDK_INT >= 29) {
-            event.tryRespond { AddDownloadEvent.ResultEvent(downloadManager.enqueue(request)) }
+            event.respond { AddDownloadEvent.ResultEvent(downloadManager.enqueue(request)) }
             return
         }
 
         activity.askForPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) { granted ->
-            event.tryRespond {
+            event.respond {
                 check(granted) { "Permission required" }
 
                 AddDownloadEvent.ResultEvent(downloadManager.enqueue(request))
@@ -280,7 +280,7 @@ open class DownloadPlugin(private val activity: ComponentActivity) {
                     cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.Downloads.DISPLAY_NAME))
                 }
 
-            event.tryRespond {
+            event.respond {
                 // Android 29 emulator throws java.lang.SecurityException: Unsupported path /storage/emulated/0/Download
                 AddDownloadEvent.ResultEvent(addCompletedDownload(File(saveToDir, displayName), mimeType))
             }
@@ -289,7 +289,7 @@ open class DownloadPlugin(private val activity: ComponentActivity) {
 
         // Create a new file manually
         activity.askForPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) { granted ->
-            event.tryRespond {
+            event.respond {
                 check(granted) { "Permission required" }
 
                 val file = File(saveToDir, fileName).let {

--- a/android/racehorse/src/main/java/org/racehorse/EventBridge.kt
+++ b/android/racehorse/src/main/java/org/racehorse/EventBridge.kt
@@ -129,7 +129,7 @@ class IsSupportedEvent(val eventType: String) : RequestEvent() {
  * @param webView The [WebView] to which the event bridge will add the connection Javascript interface.
  * @param eventBus The event bus to which events are posted.
  * @param gson The [Gson] instance that is used for event serialization.
- * @param handler The handler that is used to communicate with the [webView].
+ * @param handler The [Handler] that is used to communicate with the [webView].
  * @param connectionKey The key of the `window` that exposes the connection Javascript interface.
  */
 open class EventBridge(
@@ -158,10 +158,6 @@ open class EventBridge(
         private const val TAG = "EventBridge"
     }
 
-    init {
-        webView.addJavascriptInterface(this, connectionKey)
-    }
-
     /**
      * The cache of loaded event classes.
      */
@@ -181,6 +177,10 @@ open class EventBridge(
      * The response event for the currently pending synchronous request.
      */
     private var syncResponseEvent: ResponseEvent? = null
+
+    open fun enable() = webView.addJavascriptInterface(this, connectionKey)
+
+    open fun disable() = webView.removeJavascriptInterface(connectionKey)
 
     @JavascriptInterface
     open fun post(requestJson: String): String {

--- a/android/racehorse/src/main/java/org/racehorse/EventBridge.kt
+++ b/android/racehorse/src/main/java/org/racehorse/EventBridge.kt
@@ -183,9 +183,9 @@ open class EventBridge(
     open fun disable() = webView.removeJavascriptInterface(connectionKey)
 
     @JavascriptInterface
-    open fun post(requestJson: String): String {
+    open fun post(eventJson: String): String {
         val event = try {
-            gson.fromJson(requestJson, JsonObject::class.java).run {
+            gson.fromJson(eventJson, JsonObject::class.java).run {
                 gson.fromJson(get(PAYLOAD_KEY) ?: JsonObject(), getEventClass(get(TYPE_KEY).asString))
             }
         } catch (e: Throwable) {
@@ -220,7 +220,7 @@ open class EventBridge(
     open fun onResponse(event: ResponseEvent) {
         if (event.requestId == ORPHAN_REQUEST_ID) {
             // The response event isn't related to any request event
-            Log.i(TAG, "Orphan response ${event::class.java.name}")
+            Log.w(TAG, "Orphan response ${event::class.java.name}")
             return
         }
         if (syncRequestId == event.requestId) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "moduleResolution": "Node",
     "esModuleInterop": true,
-    "resolveJsonModule": true,
+    "isolatedModules": true,
     "strict": true,
     "target": "ES5",
     "module": "ESNext",
@@ -22,7 +22,7 @@
     }
   },
   "include": [
-    "./web/*/src/main/**/*"
+    "./web/*/src/**/*"
   ],
   "exclude": [
     "./web/example/**/*"

--- a/web/racehorse/src/main/createEventBridge.ts
+++ b/web/racehorse/src/main/createEventBridge.ts
@@ -98,12 +98,12 @@ export interface EventBridge {
    *
    * The connection is automatically established when this method is called.
    *
-   * @param type The type of event to subscribe to.
+   * @param eventType The type of event to subscribe to.
    * @param listener The listener to subscribe.
    * @returns The callback that unsubscribes the listener.
    */
   subscribe(
-    type: string,
+    eventType: string,
     /**
      * @param payload The event payload.
      */
@@ -113,9 +113,9 @@ export interface EventBridge {
   /**
    * Returns `true` if an event of the given type is supported, or `false` otherwise.
    *
-   * @param type The type of event to check.
+   * @param eventType The type of event to check.
    */
-  isSupported(type: string): boolean;
+  isSupported(eventType: string): boolean;
 }
 
 declare global {


### PR DESCRIPTION
- Added `EventBridge.enable()` that injects JS interface to the `WebView`.
- Replaces `ChainableEvent.tryRespond()` with `ChainableEvent.respond()` which always executes block and posts an event.
- `EventBridge` doesn't throw if `event.requestId` is -1.