### PR TITLE
Operations scheduler

### DIFF
--- a/android/racehorse/src/main/java/org/racehorse/ActivityPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/ActivityPlugin.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.LifecycleEventObserver
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.racehorse.utils.SerializableIntent
+import org.racehorse.utils.checkForeground
 import org.racehorse.utils.launchActivity
 import org.racehorse.utils.launchActivityForResult
 import java.io.Serializable
@@ -93,11 +94,15 @@ open class ActivityPlugin(
 
     @Subscribe
     open fun onStartActivity(event: StartActivityEvent) {
+        activity.checkForeground()
+
         event.respond(StartActivityEvent.ResultEvent(activity.launchActivity(event.intent.toIntent())))
     }
 
     @Subscribe
     open fun onStartActivityForResult(event: StartActivityForResultEvent) {
+        activity.checkForeground()
+
         val launched = activity.launchActivityForResult(event.intent.toIntent()) {
             event.respond(StartActivityForResultEvent.ResultEvent(it.resultCode, it.data?.let(::SerializableIntent)))
         }

--- a/android/racehorse/src/main/java/org/racehorse/BiometricEncryptedStoragePlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/BiometricEncryptedStoragePlugin.kt
@@ -9,6 +9,7 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
+import org.racehorse.utils.checkForeground
 import org.racehorse.utils.ifNullOrBlank
 import java.io.File
 import java.io.Serializable
@@ -94,6 +95,8 @@ open class BiometricEncryptedStoragePlugin(private val activity: FragmentActivit
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     open fun onSetBiometricEncryptedValue(event: SetBiometricEncryptedValueEvent) {
+        activity.checkForeground()
+
         val value = event.value.toByteArray(Charsets.UTF_8)
 
         val cipher = createCipher()
@@ -124,6 +127,8 @@ open class BiometricEncryptedStoragePlugin(private val activity: FragmentActivit
 
     @Subscribe(threadMode = ThreadMode.MAIN)
     open fun onGetBiometricEncryptedValue(event: GetBiometricEncryptedValueEvent) {
+        activity.checkForeground()
+
         val record = encryptedStorage.getRecord(event.key)
             ?: return event.respond(GetEncryptedValueEvent.ResultEvent(null))
 

--- a/android/racehorse/src/main/java/org/racehorse/BiometricPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/BiometricPlugin.kt
@@ -7,6 +7,7 @@ import androidx.biometric.BiometricManager
 import androidx.fragment.app.FragmentActivity
 import com.google.gson.annotations.SerializedName
 import org.greenrobot.eventbus.Subscribe
+import org.racehorse.utils.checkForeground
 import org.racehorse.utils.launchActivityForResult
 
 enum class BiometricAuthenticator(val value: Int) {
@@ -88,6 +89,8 @@ class BiometricPlugin(private val activity: FragmentActivity) {
 
     @Subscribe
     fun onEnrollBiometric(event: EnrollBiometricEvent) {
+        activity.checkForeground()
+
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
             // Too old for this shit
             event.respond(EnrollBiometricEvent.ResultEvent(false))

--- a/android/racehorse/src/main/java/org/racehorse/FacebookLoginPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/FacebookLoginPlugin.kt
@@ -8,6 +8,7 @@ import com.facebook.FacebookException
 import com.facebook.login.LoginManager
 import com.facebook.login.LoginResult
 import org.greenrobot.eventbus.Subscribe
+import org.racehorse.utils.checkForeground
 import java.io.Serializable
 
 class SerializableFacebookAccessToken(
@@ -67,6 +68,8 @@ open class FacebookLoginPlugin(private val activity: ComponentActivity) {
 
     @Subscribe
     fun onFacebookLogIn(event: FacebookLogInEvent) {
+        activity.checkForeground()
+
         val callbackManager = CallbackManager.Factory.create()
 
         loginManager.registerCallback(callbackManager, object : FacebookCallback<LoginResult> {

--- a/android/racehorse/src/main/java/org/racehorse/FacebookSharePlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/FacebookSharePlugin.kt
@@ -7,6 +7,7 @@ import com.facebook.share.model.ShareHashtag
 import com.facebook.share.model.ShareLinkContent
 import com.facebook.share.widget.ShareDialog
 import org.greenrobot.eventbus.Subscribe
+import org.racehorse.utils.checkForeground
 import org.racehorse.utils.launchActivityForResult
 
 class FacebookShareLinkEvent(
@@ -23,6 +24,8 @@ class FacebookSharePlugin(val activity: ComponentActivity) {
 
     @Subscribe
     fun onFacebookShareLink(event: FacebookShareLinkEvent) {
+        activity.checkForeground()
+
         val callbackManager = CallbackManager.Factory.create()
 
         activity.launchActivityForResult(

--- a/android/racehorse/src/main/java/org/racehorse/GooglePayPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/GooglePayPlugin.kt
@@ -311,7 +311,7 @@ open class GooglePayPlugin(
     )
 
     @Subscribe
-    fun onGooglePayRequestSelectTokenEvent(event: GooglePayRequestSelectTokenEvent) = runOperationInForeground(
+    fun onGooglePayRequestSelectToken(event: GooglePayRequestSelectTokenEvent) = runOperationInForeground(
         { requestCode ->
             tapAndPayClient.requestSelectToken(
                 activity,
@@ -324,7 +324,7 @@ open class GooglePayPlugin(
     )
 
     @Subscribe
-    fun onGooglePayRequestDeleteTokenEvent(event: GooglePayRequestDeleteTokenEvent) = runOperationInForeground(
+    fun onGooglePayRequestDeleteToken(event: GooglePayRequestDeleteTokenEvent) = runOperationInForeground(
         { requestCode ->
             tapAndPayClient.requestDeleteToken(
                 activity,
@@ -337,7 +337,7 @@ open class GooglePayPlugin(
     )
 
     @Subscribe
-    fun onGooglePayCreateWalletEvent(event: GooglePayCreateWalletEvent) = runOperationInForeground(
+    fun onGooglePayCreateWallet(event: GooglePayCreateWalletEvent) = runOperationInForeground(
         { requestCode -> tapAndPayClient.createWallet(activity, requestCode) },
         { event.respond(VoidEvent()) }
     )

--- a/android/racehorse/src/main/java/org/racehorse/GoogleSignInPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/GoogleSignInPlugin.kt
@@ -7,6 +7,7 @@ import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.android.gms.auth.api.signin.GoogleSignInStatusCodes
 import com.google.android.gms.common.api.ApiException
 import org.greenrobot.eventbus.Subscribe
+import org.racehorse.utils.checkForeground
 import org.racehorse.utils.launchActivityForResult
 import java.io.Serializable
 
@@ -77,6 +78,8 @@ open class GoogleSignInPlugin(
 
     @Subscribe
     open fun onGoogleSignIn(event: GoogleSignInEvent) {
+        activity.checkForeground()
+
         val launched = activity.launchActivityForResult(googleSignInClient.signInIntent) {
             event.respond {
                 val task = GoogleSignIn.getSignedInAccountFromIntent(it.data)

--- a/android/racehorse/src/main/java/org/racehorse/PermissionsPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/PermissionsPlugin.kt
@@ -6,6 +6,7 @@ import androidx.activity.ComponentActivity
 import androidx.core.app.ActivityCompat
 import org.greenrobot.eventbus.Subscribe
 import org.racehorse.utils.askForPermissions
+import org.racehorse.utils.checkForeground
 import org.racehorse.utils.isPermissionGranted
 import org.racehorse.webview.GeolocationPermissionsShowPromptEvent
 import org.racehorse.webview.PermissionRequestEvent
@@ -98,6 +99,8 @@ open class PermissionsPlugin(private val activity: ComponentActivity) {
 
     @Subscribe
     open fun onAskForPermission(event: AskForPermissionEvent) {
+        activity.checkForeground()
+
         activity.askForPermissions(event.permissions) {
             event.respond(AskForPermissionEvent.ResultEvent(it))
         }

--- a/android/racehorse/src/main/java/org/racehorse/utils/Activities.kt
+++ b/android/racehorse/src/main/java/org/racehorse/utils/Activities.kt
@@ -11,6 +11,8 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
 import java.util.UUID
 
 /**
@@ -106,3 +108,10 @@ fun ComponentActivity.askForPermission(permission: String, callback: (granted: B
  */
 fun Context.isPermissionGranted(permission: String) =
     ContextCompat.checkSelfPermission(this, permission) == PackageManager.PERMISSION_GRANTED
+
+/**
+ * Throws if activity isn't in foreground.
+ */
+fun LifecycleOwner.checkForeground() {
+    check(lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) { "Must be in foreground" }
+}

--- a/android/racehorse/src/main/java/org/racehorse/utils/Activities.kt
+++ b/android/racehorse/src/main/java/org/racehorse/utils/Activities.kt
@@ -8,6 +8,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultCallback
 import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.ActivityResultRegistryOwner
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
@@ -35,7 +36,7 @@ fun Context.launchActivity(intent: Intent) = try {
  * @param callback The callback that receives the result from the started activity.
  * @return `true` if activity has started, or `false` if there's no matching activity.
  */
-fun <I, O> ComponentActivity.launchActivityForResult(
+fun <I, O> ActivityResultRegistryOwner.launchActivityForResult(
     contract: ActivityResultContract<I, O>,
     input: I,
     callback: ActivityResultCallback<O>
@@ -61,7 +62,7 @@ fun <I, O> ComponentActivity.launchActivityForResult(
  * @param callback The callback that receives the result intent from the started activity.
  * @return `true` if activity has started, or `false` if there's no matching activity.
  */
-fun ComponentActivity.launchActivityForResult(intent: Intent, callback: ActivityResultCallback<ActivityResult>) =
+fun ActivityResultRegistryOwner.launchActivityForResult(intent: Intent, callback: ActivityResultCallback<ActivityResult>) =
     launchActivityForResult(ActivityResultContracts.StartActivityForResult(), intent, callback)
 
 /**

--- a/web/example/src/examples/GeolocationExample.tsx
+++ b/web/example/src/examples/GeolocationExample.tsx
@@ -9,7 +9,9 @@ export function GeolocationExample() {
       <h2>{'Geolocation'}</h2>
 
       {window.location.protocol !== 'https:' && (
-        <p style={{ color: 'red' }}>{'Pick "release" build variant to enable geolocation'}</p>
+        <p style={{ color: 'red' }}>
+          <i>{'Pick "release" build variant to enable geolocation'}</i>
+        </p>
       )}
 
       <button

--- a/web/racehorse/src/main/createDownloadManager.ts
+++ b/web/racehorse/src/main/createDownloadManager.ts
@@ -1,4 +1,4 @@
-import { EventBridge } from './createEventBridge';
+import { Event, EventBridge } from './createEventBridge';
 
 /**
  * The download description.
@@ -249,11 +249,12 @@ export interface DownloadManager {
 export function createDownloadManager(eventBridge: EventBridge): DownloadManager {
   return {
     addDownload: (uri, options) =>
-      new Promise(resolve => {
-        resolve(Object.assign({}, options, { uri, headers: Array.from(new Headers(options?.headers)) }));
-      })
-        .then(payload => eventBridge.requestAsync({ type: 'org.racehorse.AddDownloadEvent', payload }))
-        .then(event => event.payload.id),
+      new Promise<Event>(resolve => {
+        const headers = Array.from(new Headers(options?.headers));
+        const payload = Object.assign({}, options, { uri, headers });
+
+        resolve(eventBridge.requestAsync({ type: 'org.racehorse.AddDownloadEvent', payload }));
+      }).then(event => event.payload.id),
 
     getDownload: id =>
       eventBridge.request({ type: 'org.racehorse.GetDownloadEvent', payload: { id } }).payload.download,

--- a/web/racehorse/src/main/createGooglePlayReferrerManager.ts
+++ b/web/racehorse/src/main/createGooglePlayReferrerManager.ts
@@ -10,11 +10,11 @@ export interface GooglePlayReferrerManager {
  * @param eventBridge The underlying event bridge.
  */
 export function createGooglePlayReferrerManager(eventBridge: EventBridge): GooglePlayReferrerManager {
-  let referrerPromise: Promise<string> | undefined;
+  let promise: Promise<string> | undefined;
 
   return {
     getGooglePlayReferrer: () =>
-      (referrerPromise ||= eventBridge
+      (promise ||= eventBridge
         .requestAsync({ type: 'org.racehorse.GetGooglePlayReferrerEvent' })
         .then(event => event.payload.referrer)),
   };

--- a/web/racehorse/src/main/createJoiner.ts
+++ b/web/racehorse/src/main/createJoiner.ts
@@ -1,0 +1,37 @@
+/**
+ * @template T The operation result.
+ */
+export interface Joiner<T> {
+  /**
+   * Returns `true` if joiner currently has a pending operation, or `false` otherwise.
+   */
+  isPending(): boolean;
+
+  /**
+   * Invokes the operation. If there's a pending operation than this call would return its promise, and the given
+   * operation callback won't be called.
+   *
+   * @param operation The operation to invoke.
+   */
+  join(operation: () => Promise<T>): Promise<T>;
+}
+
+/**
+ * Joiner invokes the operation callback if there's no pending callback, otherwise it returns the result of the pending
+ * operation.
+ *
+ * @template T The operation result.
+ */
+export function createJoiner<T>(): Joiner<T> {
+  let promise: Promise<T> | undefined;
+
+  return {
+    isPending: () => promise !== undefined,
+
+    join: operation =>
+      (promise ||= operation().then(result => {
+        promise = undefined;
+        return result;
+      })),
+  };
+}

--- a/web/racehorse/src/main/createScheduler.ts
+++ b/web/racehorse/src/main/createScheduler.ts
@@ -1,0 +1,47 @@
+import { noop } from './utils';
+
+export interface Scheduler {
+  /**
+   * Returns `true` if scheduler currently has a pending operation, or `false` otherwise.
+   */
+  isPending(): boolean;
+
+  /**
+   * Schedules an operation callback invocation after all previously scheduled operations are completed.
+   *
+   * @param operation The operation to schedule.
+   */
+  schedule<T>(operation: () => Promise<T>): Promise<T>;
+}
+
+/**
+ * Schedules an operation callback invocation after all previously scheduled operations are completed.
+ */
+export function createScheduler(): Scheduler {
+  let promise: Promise<unknown> = Promise.resolve();
+  let pending = false;
+
+  return {
+    isPending: () => pending,
+
+    schedule: operation => {
+      pending = true;
+
+      const operationPromise = promise
+        .then(noop, noop)
+        .then(operation)
+        .then(
+          result => {
+            pending = promise !== operationPromise;
+            return result;
+          },
+          reason => {
+            pending = promise !== operationPromise;
+            throw reason;
+          }
+        );
+
+      return (promise = operationPromise);
+    },
+  };
+}

--- a/web/racehorse/src/main/index.ts
+++ b/web/racehorse/src/main/index.ts
@@ -17,6 +17,7 @@ import { createKeyboardManager } from './createKeyboardManager';
 import { createNetworkManager } from './createNetworkManager';
 import { createNotificationsManager } from './createNotificationsManager';
 import { createPermissionsManager } from './createPermissionsManager';
+import { createScheduler } from './createScheduler';
 
 export { createActivityManager, Intent, Activity, ActivityState } from './createActivityManager';
 export { createBiometricEncryptedStorageManager } from './createBiometricEncryptedStorageManager';
@@ -38,12 +39,13 @@ export {
 } from './createGooglePayManager';
 export { createGooglePlayReferrerManager } from './createGooglePlayReferrerManager';
 export { createGoogleSignInManager } from './createGoogleSignInManager';
+export { createJoiner } from './createJoiner';
 export { createKeyboardManager } from './createKeyboardManager';
 export { createNetworkManager } from './createNetworkManager';
 export { createNotificationsManager } from './createNotificationsManager';
 export { createPermissionsManager } from './createPermissionsManager';
+export { createScheduler } from './createScheduler';
 
-export type { ActivityManager, ActivityResult, ActivityInfo } from './createActivityManager';
 export type { BiometricEncryptedStorageManager, BiometricConfig } from './createBiometricEncryptedStorageManager';
 export type { BiometricManager } from './createBiometricManager';
 export type { DeepLinkManager } from './createDeepLinkManager';
@@ -65,18 +67,23 @@ export type {
 } from './createGooglePayManager';
 export type { GooglePlayReferrerManager } from './createGooglePlayReferrerManager';
 export type { GoogleSignInManager, GoogleSignInAccount } from './createGoogleSignInManager';
+export type { Joiner } from './createJoiner';
+export type { ActivityManager, ActivityResult, ActivityInfo } from './createActivityManager';
 export type { KeyboardManager, KeyboardStatus } from './createKeyboardManager';
 export type { NetworkManager, NetworkType, NetworkStatus } from './createNetworkManager';
 export type { NotificationsManager } from './createNotificationsManager';
 export type { PermissionsManager } from './createPermissionsManager';
+export type { Scheduler } from './createScheduler';
+
+export const uiScheduler = createScheduler();
 
 export const eventBridge = createEventBridge();
 
-export const activityManager = createActivityManager(eventBridge);
+export const activityManager = createActivityManager(eventBridge, uiScheduler);
 
-export const biometricEncryptedStorageManager = createBiometricEncryptedStorageManager(eventBridge);
+export const biometricEncryptedStorageManager = createBiometricEncryptedStorageManager(eventBridge, uiScheduler);
 
-export const biometricManager = createBiometricManager(eventBridge);
+export const biometricManager = createBiometricManager(eventBridge, uiScheduler);
 
 export const deepLinkManager = createDeepLinkManager(eventBridge);
 
@@ -86,19 +93,19 @@ export const downloadManager = createDownloadManager(eventBridge);
 
 export const evergreenManager = createEvergreenManager(eventBridge);
 
-export const facebookLoginManager = createFacebookLoginManager(eventBridge);
+export const facebookLoginManager = createFacebookLoginManager(eventBridge, uiScheduler);
 
-export const facebookShareManager = createFacebookShareManager(eventBridge);
+export const facebookShareManager = createFacebookShareManager(eventBridge, uiScheduler);
 
 export const encryptedStorageManager = createEncryptedStorageManager(eventBridge);
 
 export const firebaseManager = createFirebaseManager(eventBridge);
 
-export const googlePayManager = createGooglePayManager(eventBridge);
+export const googlePayManager = createGooglePayManager(eventBridge, uiScheduler);
 
 export const googlePlayReferrerManager = createGooglePlayReferrerManager(eventBridge);
 
-export const googleSignInManager = createGoogleSignInManager(eventBridge);
+export const googleSignInManager = createGoogleSignInManager(eventBridge, uiScheduler);
 
 export const keyboardManager = createKeyboardManager(eventBridge);
 
@@ -106,4 +113,4 @@ export const networkManager = createNetworkManager(eventBridge);
 
 export const notificationsManager = createNotificationsManager(eventBridge);
 
-export const permissionsManager = createPermissionsManager(eventBridge);
+export const permissionsManager = createPermissionsManager(eventBridge, uiScheduler);

--- a/web/racehorse/src/main/index.ts
+++ b/web/racehorse/src/main/index.ts
@@ -46,6 +46,7 @@ export { createNotificationsManager } from './createNotificationsManager';
 export { createPermissionsManager } from './createPermissionsManager';
 export { createScheduler } from './createScheduler';
 
+export type { ActivityManager, ActivityResult, ActivityInfo } from './createActivityManager';
 export type { BiometricEncryptedStorageManager, BiometricConfig } from './createBiometricEncryptedStorageManager';
 export type { BiometricManager } from './createBiometricManager';
 export type { DeepLinkManager } from './createDeepLinkManager';
@@ -68,7 +69,6 @@ export type {
 export type { GooglePlayReferrerManager } from './createGooglePlayReferrerManager';
 export type { GoogleSignInManager, GoogleSignInAccount } from './createGoogleSignInManager';
 export type { Joiner } from './createJoiner';
-export type { ActivityManager, ActivityResult, ActivityInfo } from './createActivityManager';
 export type { KeyboardManager, KeyboardStatus } from './createKeyboardManager';
 export type { NetworkManager, NetworkType, NetworkStatus } from './createNetworkManager';
 export type { NotificationsManager } from './createNotificationsManager';

--- a/web/racehorse/src/test/createJoiner.test.ts
+++ b/web/racehorse/src/test/createJoiner.test.ts
@@ -1,0 +1,29 @@
+import { createJoiner } from '../main';
+
+describe('createJoiner', () => {
+  test('invokes the operation', async () => {
+    const operationMock = jest.fn(() => Promise.resolve('aaa'));
+    const joiner = createJoiner();
+
+    expect(joiner.isPending()).toBe(false);
+
+    const promise = joiner.join(operationMock);
+
+    expect(joiner.isPending()).toBe(true);
+    expect(operationMock).toHaveBeenCalledTimes(1);
+
+    await expect(promise).resolves.toBe('aaa');
+
+    expect(operationMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('joins the pending operation', async () => {
+    const joiner = createJoiner();
+
+    joiner.join(() => Promise.resolve('aaa'));
+
+    const promise = joiner.join(() => Promise.resolve('bbb'));
+
+    await expect(promise).resolves.toBe('aaa');
+  });
+});

--- a/web/racehorse/src/test/createScheduler.test.ts
+++ b/web/racehorse/src/test/createScheduler.test.ts
@@ -1,0 +1,85 @@
+import { createScheduler } from '../main';
+
+describe('createScheduler', () => {
+  test('invokes the operation', async () => {
+    const operationMock = jest.fn(() => Promise.resolve('aaa'));
+    const scheduler = createScheduler();
+
+    expect(scheduler.isPending()).toBe(false);
+
+    const promise = scheduler.schedule(operationMock);
+
+    expect(scheduler.isPending()).toBe(true);
+    expect(operationMock).toHaveBeenCalledTimes(0);
+
+    await expect(promise).resolves.toBe('aaa');
+
+    expect(operationMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('invokes operations consequently', async () => {
+    let operation1Completed = false;
+
+    const operation1Mock = jest.fn(() =>
+      Promise.resolve().then(() => {
+        operation1Completed = true;
+      })
+    );
+    const operation2Mock = jest.fn(() => {
+      expect(operation1Completed).toBe(true);
+      return Promise.resolve('aaa');
+    });
+
+    const scheduler = createScheduler();
+
+    scheduler.schedule(operation1Mock);
+
+    await expect(scheduler.schedule(operation2Mock)).resolves.toBe('aaa');
+
+    expect(operation2Mock).toHaveBeenCalledTimes(1);
+    expect(scheduler.isPending()).toBe(false);
+  });
+
+  test('result from the previous operation is not visible to the next operation', async () => {
+    const operationMock = jest.fn();
+
+    const scheduler = createScheduler();
+
+    scheduler.schedule(() => Promise.resolve('aaa'));
+
+    await scheduler.schedule(operationMock);
+
+    expect(operationMock).toHaveBeenCalledTimes(1);
+    expect(operationMock.mock.calls[0]).toStrictEqual([undefined]);
+  });
+
+  test('ignores the rejection of the preceding operation', async () => {
+    const operationMock = jest.fn();
+
+    const scheduler = createScheduler();
+
+    scheduler.schedule(() => Promise.reject('aaa'));
+
+    await scheduler.schedule(operationMock);
+
+    expect(operationMock).toHaveBeenCalledTimes(1);
+    expect(operationMock.mock.calls[0]).toStrictEqual([undefined]);
+  });
+
+  test('pending status is preserved', async () => {
+    const scheduler = createScheduler();
+
+    expect(scheduler.isPending()).toBe(false);
+
+    const promise1 = scheduler.schedule(() => Promise.resolve('aaa'));
+    const promise2 = scheduler.schedule(() => Promise.resolve('bbb'));
+
+    await promise1;
+
+    expect(scheduler.isPending()).toBe(true);
+
+    await promise2;
+
+    expect(scheduler.isPending()).toBe(false);
+  });
+});


### PR DESCRIPTION
Events that throw an exception if the app is in the background:
- `StartActivityEvent`
- `StartActivityForResultEvent`
- `SetBiometricEncryptedValueEvent`
- `GetBiometricEncryptedValueEvent`
- `EnrollBiometricEvent`
- `FacebookLogInEvent`
- `FacebookShareLinkEvent`
- `GooglePayViewTokenEvent`
- `GooglePayPushTokenizeEvent`
- `GooglePayTokenizeEvent`
- `GooglePayRequestSelectTokenEvent`
- `GooglePayRequestDeleteTokenEvent`
- `GooglePayCreateWalletEvent`
- `GoogleSignInEvent`
- `AskForPermissionEvent`

API methods that share the same scheduler (calls are deferred until the preceding operation is completed):
- `activityManager.startActivityForResult`
- `biometricEncryptedStorageManager.set`
- `biometricEncryptedStorageManager.get`
- `biometricManager.enrollBiometric`
- `facebookLoginManager.logIn`
- `facebookShareManager.shareLink`
- `googlePayManager.viewToken`
- `googlePayManager.pushTokenize`
- `googlePayManager.tokenize`
- `googlePayManager.requestSelectToken`
- `googlePayManager.requestDeleteToken`
- `googlePayManager.createWallet`
- `googleSignInManager.signIn`
- `permissionsManager.askForPermission`