### PR TITLE
Fixed authentication timeout support in biometric storage

### DIFF
--- a/android/example/src/main/java/com/example/MainActivity.kt
+++ b/android/example/src/main/java/com/example/MainActivity.kt
@@ -3,7 +3,6 @@ package com.example
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Bundle
-import android.security.keystore.KeyGenParameterSpec
 import android.webkit.CookieManager
 import android.webkit.WebResourceResponse
 import android.webkit.WebSettings
@@ -74,16 +73,7 @@ class MainActivity : AppCompatActivity() {
         eventBus.register(FacebookLoginPlugin(this))
         eventBus.register(FacebookSharePlugin(this))
         eventBus.register(BiometricPlugin(this))
-        eventBus.register(object :
-            BiometricEncryptedStoragePlugin(this@MainActivity, File(filesDir, "biometric_storage")) {
-
-            override fun configureSecretKey(key: String, builder: KeyGenParameterSpec.Builder) {
-                // Allow multiple set and get storage operations during 5 seconds
-                // after the user was successfully authenticated using biometrics.
-                builder.setUserAuthenticationRequired(true)
-                builder.setUserAuthenticationValidityDurationSeconds(5)
-            }
-        })
+        eventBus.register(BiometricEncryptedStoragePlugin(this, File(filesDir, "biometric_storage")))
 
         // From the example app
         eventBus.register(ToastPlugin(this))

--- a/android/racehorse/src/main/java/org/racehorse/BiometricEncryptedStoragePlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/BiometricEncryptedStoragePlugin.kt
@@ -119,7 +119,7 @@ open class BiometricEncryptedStoragePlugin(private val activity: FragmentActivit
             ?: return event.respond(GetEncryptedValueEvent.ResultEvent(null))
 
         val secretKey = getSecretKey(event.key)
-            ?: throw KeyPermanentlyInvalidatedException("Key permanently invalidated")
+            ?: return event.respond(ExceptionEvent(KeyPermanentlyInvalidatedException("Key permanently invalidated")))
 
         val cipher = createCipher()
 

--- a/android/racehorse/src/main/java/org/racehorse/DownloadPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/DownloadPlugin.kt
@@ -236,9 +236,9 @@ open class DownloadPlugin(private val activity: ComponentActivity) {
             return
         }
 
-        activity.askForPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) { granted ->
+        activity.askForPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) { isGranted ->
             event.respond {
-                check(granted) { "Permission required" }
+                check(isGranted) { "Permission required" }
 
                 AddDownloadEvent.ResultEvent(downloadManager.enqueue(request))
             }
@@ -288,9 +288,9 @@ open class DownloadPlugin(private val activity: ComponentActivity) {
         }
 
         // Create a new file manually
-        activity.askForPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) { granted ->
+        activity.askForPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) { isGranted ->
             event.respond {
-                check(granted) { "Permission required" }
+                check(isGranted) { "Permission required" }
 
                 val file = File(saveToDir, fileName).let {
                     // Prevent overwrite

--- a/android/racehorse/src/main/java/org/racehorse/DownloadPlugin.kt
+++ b/android/racehorse/src/main/java/org/racehorse/DownloadPlugin.kt
@@ -187,7 +187,7 @@ open class DownloadPlugin(private val activity: ComponentActivity) {
 
             "http", "https" -> enqueueDownload(event, uri)
 
-            else -> throw IllegalArgumentException("Unsupported URI")
+            else -> event.respond(ExceptionEvent(IllegalArgumentException("Unsupported URI")))
         }
     }
 

--- a/android/racehorse/src/main/java/org/racehorse/EncryptedStorage.kt
+++ b/android/racehorse/src/main/java/org/racehorse/EncryptedStorage.kt
@@ -37,7 +37,7 @@ open class EncryptedStorage(private val storageDir: File) {
      * @param value The byte array the holds the data.
      * @return `true` if the key was successfully persisted, or `false` otherwise.
      */
-    fun set(cipher: Cipher, key: String, value: ByteArray): Boolean {
+    open fun set(cipher: Cipher, key: String, value: ByteArray): Boolean {
         val valueHash = MessageDigest.getInstance(HASH_ALGORITHM).digest(value)
 
         val ivSize = ByteBuffer.allocate(IV_SIZE_SIZE).putInt(cipher.iv.size).array()
@@ -58,7 +58,7 @@ open class EncryptedStorage(private val storageDir: File) {
      * The first element holds the initialization vector.
      * The second element holds the encrypted bytes. Use [decrypt] to read the value from the encrypted bytes.
      */
-    fun getRecord(key: String): EncryptedRecord? {
+    open fun getRecord(key: String): EncryptedRecord? {
         val file = getFile(key)
 
         if (!file.exists()) {
@@ -77,19 +77,19 @@ open class EncryptedStorage(private val storageDir: File) {
     /**
      * Returns `true` if there's a value associated with the key in the storage, or `false` otherwise.
      */
-    fun has(key: String) = getFile(key).exists()
+    open fun has(key: String) = getFile(key).exists()
 
     /**
      * Deletes the value associated with the key from the storage.
      */
-    fun delete(key: String) = getFile(key).delete()
+    open fun delete(key: String) = getFile(key).delete()
 
     /**
      * Decrypts the encrypted value that was retrieved via [getRecord].
      *
      * Returns the decrypted value or `null` if decryption failed because of the invalid decryption key.
      */
-    fun decrypt(cipher: Cipher, encryptedValue: ByteArray): ByteArray? {
+    open fun decrypt(cipher: Cipher, encryptedValue: ByteArray): ByteArray? {
         return try {
             val bytes = cipher.doFinal(encryptedValue)
 
@@ -99,7 +99,7 @@ open class EncryptedStorage(private val storageDir: File) {
         }
     }
 
-    fun getFile(key: String): File {
+    open fun getFile(key: String): File {
         storageDir.mkdirs()
 
         val keyHash = MessageDigest.getInstance(HASH_ALGORITHM).digest(key.toByteArray())

--- a/android/racehorse/src/main/java/org/racehorse/EventBridge.kt
+++ b/android/racehorse/src/main/java/org/racehorse/EventBridge.kt
@@ -249,8 +249,6 @@ open class EventBridge(
 
     @Subscribe
     open fun onSubscriberException(event: SubscriberExceptionEvent) {
-        event.throwable.printStackTrace()
-
         (event.causingEvent as? ChainableEvent)?.respond(ExceptionEvent(event.throwable))
     }
 

--- a/web/example/src/examples/BiometricEncryptedStorageExample.tsx
+++ b/web/example/src/examples/BiometricEncryptedStorageExample.tsx
@@ -5,6 +5,7 @@ import { BiometricAuthenticator, biometricEncryptedStorageManager } from 'raceho
 export function BiometricEncryptedStorageExample() {
   const [key, setKey] = useState('my_key');
   const [value, setValue] = useState('my_value');
+  const [authenticationValidityDuration, setAuthenticationValidityDuration] = useState(-1);
   const [authenticators, setAuthenticators] = useState<BiometricAuthenticator[]>([
     BiometricAuthenticator.BIOMETRIC_STRONG,
   ]);
@@ -29,6 +30,23 @@ export function BiometricEncryptedStorageExample() {
           <option value={BiometricAuthenticator.BIOMETRIC_WEAK}>{'Biometric weak'}</option>
           <option value={BiometricAuthenticator.DEVICE_CREDENTIAL}>{'Device credential'}</option>
         </select>
+      </p>
+
+      <p>
+        {'Authentication validity duration: ' +
+          (authenticationValidityDuration === -1 ? 'Disabled' : authenticationValidityDuration + ' seconds')}
+        <br />
+        <input
+          type="range"
+          value={authenticationValidityDuration}
+          min={-1}
+          max={10}
+          step={1}
+          style={{ margin: '0.5rem 3rem 0', width: 'calc(100% - 6rem)' }}
+          onChange={event => {
+            setAuthenticationValidityDuration(event.target.valueAsNumber);
+          }}
+        />
       </p>
 
       <p>
@@ -82,6 +100,7 @@ export function BiometricEncryptedStorageExample() {
               .set(key, value, {
                 title: 'Set value to storage',
                 authenticators,
+                authenticationValidityDuration,
               })
               .then(isSuccessful => {
                 if (!isSuccessful) {

--- a/web/example/src/examples/BiometricEncryptedStorageExample.tsx
+++ b/web/example/src/examples/BiometricEncryptedStorageExample.tsx
@@ -1,87 +1,101 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { FormattedJSON } from '../components/FormattedJSON';
-import { BiometricAuthenticator, BiometricConfig, biometricEncryptedStorageManager } from 'racehorse';
-
-const biometricConfig: BiometricConfig = {
-  title: 'Authentication required',
-  authenticators: [BiometricAuthenticator.BIOMETRIC_STRONG],
-};
+import { BiometricAuthenticator, biometricEncryptedStorageManager } from 'racehorse';
 
 export function BiometricEncryptedStorageExample() {
   const [key, setKey] = useState('my_key');
   const [value, setValue] = useState('my_value');
-  const [persistedValue, setPersistedValue] = useState<string | null>(null);
-
-  useEffect(() => {
-    biometricEncryptedStorageManager.get(key).then(setPersistedValue);
-  }, []);
+  const [authenticators, setAuthenticators] = useState<BiometricAuthenticator[]>([
+    BiometricAuthenticator.BIOMETRIC_STRONG,
+  ]);
+  const [storedValue, setStoredValue] = useState<string | null>(null);
 
   return (
     <>
       <h2>{'Biometric encrypted storage'}</h2>
 
-      <div style={{ display: 'flex', gap: '10px' }}>
-        <div>
-          {'Key:'}
-          <br />
-          <input
-            type="text"
-            value={key}
-            size={10}
-            onChange={event => {
-              setKey(event.target.value);
-            }}
-          />
-        </div>
-
-        <div>
-          {'Value:'}
-          <br />
-          <input
-            type="text"
-            value={value}
-            size={10}
-            onChange={event => {
-              setValue(event.target.value);
-            }}
-          />
-        </div>
-      </div>
+      <p>
+        {'Authenticators: '}
+        <select
+          multiple={true}
+          value={authenticators}
+          onChange={event => {
+            setAuthenticators(
+              Array.from(event.target.selectedOptions).map(option => option.value as BiometricAuthenticator)
+            );
+          }}
+        >
+          <option value={BiometricAuthenticator.BIOMETRIC_STRONG}>{'Biometric strong'}</option>
+          <option value={BiometricAuthenticator.BIOMETRIC_WEAK}>{'Biometric weak'}</option>
+          <option value={BiometricAuthenticator.DEVICE_CREDENTIAL}>{'Device credential'}</option>
+        </select>
+      </p>
 
       <p>
+        {'Key:'}
+        <br />
+        <input
+          type="text"
+          value={key}
+          size={10}
+          onChange={event => {
+            setKey(event.target.value);
+          }}
+        />{' '}
         <button
           onClick={() => {
-            biometricEncryptedStorageManager.get(key).then(setPersistedValue);
+            biometricEncryptedStorageManager
+              .get(key, {
+                title: 'Get value from storage',
+                authenticators,
+              })
+              .then(setStoredValue);
           }}
         >
           {'Get value'}
         </button>{' '}
         <button
           onClick={() => {
-            biometricEncryptedStorageManager.set(key, value, biometricConfig).then(isSuccessful => {
-              if (isSuccessful) {
-                biometricEncryptedStorageManager.get(key, biometricConfig).then(setPersistedValue);
-              } else {
-                console.log('Cannot set biometric storage entry: ' + key);
-              }
-            });
-          }}
-        >
-          {'Set value'}
-        </button>{' '}
-        <button
-          onClick={() => {
             if (biometricEncryptedStorageManager.delete(key)) {
-              biometricEncryptedStorageManager.get(key, biometricConfig).then(setPersistedValue);
+              setStoredValue(null);
             }
           }}
         >
-          {'Delete value'}
+          {'❌ Delete key'}
         </button>
       </p>
 
-      {'Persisted value: '}
-      <FormattedJSON value={persistedValue} />
+      <p>
+        {'Value:'}
+        <br />
+        <input
+          type="text"
+          value={value}
+          size={10}
+          onChange={event => {
+            setValue(event.target.value);
+          }}
+        />{' '}
+        <button
+          onClick={() => {
+            biometricEncryptedStorageManager
+              .set(key, value, {
+                title: 'Set value to storage',
+                authenticators,
+              })
+              .then(isSuccessful => {
+                if (!isSuccessful) {
+                  console.log('❌ Cannot set biometric storage entry: ' + key);
+                }
+              });
+          }}
+        >
+          {'Set value'}
+        </button>
+      </p>
+
+      {'Stored value: '}
+      <FormattedJSON value={storedValue} />
     </>
   );
 }

--- a/web/example/src/examples/BiometricExample.tsx
+++ b/web/example/src/examples/BiometricExample.tsx
@@ -3,7 +3,7 @@ import { BiometricAuthenticator, biometricManager, BiometricStatus } from 'raceh
 
 export function BiometricExample() {
   const [authenticators, setAuthenticators] = useState<BiometricAuthenticator[]>([
-    BiometricAuthenticator.BIOMETRIC_WEAK,
+    BiometricAuthenticator.BIOMETRIC_STRONG,
   ]);
 
   const status = useMemo(() => biometricManager.getBiometricStatus(authenticators), [authenticators]);

--- a/web/example/src/examples/CookieExample.tsx
+++ b/web/example/src/examples/CookieExample.tsx
@@ -25,7 +25,7 @@ export function CookieExample() {
             rerender();
           }}
         >
-          {'Clear value'}
+          {'❌ Delete value'}
         </button>
       </p>
 

--- a/web/example/src/examples/EncryptedStorageExample.tsx
+++ b/web/example/src/examples/EncryptedStorageExample.tsx
@@ -6,82 +6,74 @@ export function EncryptedStorageExample() {
   const [key, setKey] = useState('my_key');
   const [value, setValue] = useState('my_value');
   const [password, setPassword] = useState('my_password');
-  const [persistedValue, setPersistedValue] = useState<string | null>(null);
+  const [storedValue, setStoredValue] = useState<string | null>(null);
 
   useEffect(() => {
-    encryptedStorageManager.get(key, password).then(setPersistedValue);
+    encryptedStorageManager.get(key, password).then(setStoredValue);
   }, [key, value, password]);
 
   return (
     <>
       <h2>{'Encrypted storage'}</h2>
-
-      <div style={{ display: 'flex', gap: '10px' }}>
-        <div>
-          {'Key:'}
-          <br />
-          <input
-            type="text"
-            value={key}
-            size={10}
-            onChange={event => {
-              setKey(event.target.value);
-            }}
-          />
-        </div>
-
-        <div>
-          {'Value:'}
-          <br />
-          <input
-            type="text"
-            value={value}
-            size={10}
-            onChange={event => {
-              setValue(event.target.value);
-            }}
-          />
-        </div>
-
-        <div>
-          {'Password:'}
-          <br />
-          <input
-            type="text"
-            value={password}
-            size={10}
-            onChange={event => {
-              setPassword(event.target.value);
-            }}
-          />
-        </div>
-      </div>
-
       <p>
+        {'Key:'}
+        <br />
+        <input
+          type="text"
+          value={key}
+          size={10}
+          onChange={event => {
+            setKey(event.target.value);
+          }}
+        />{' '}
+        <button
+          onClick={() => {
+            if (encryptedStorageManager.delete(key)) {
+              setStoredValue(null);
+            }
+          }}
+        >
+          {'❌ Delete key'}
+        </button>
+      </p>
+      <p>
+        {'Value:'}
+        <br />
+        <input
+          type="text"
+          value={value}
+          size={10}
+          onChange={event => {
+            setValue(event.target.value);
+          }}
+        />
+      </p>
+      <p>
+        {'Password:'}
+        <br />
+        <input
+          type="text"
+          value={password}
+          size={10}
+          onChange={event => {
+            setPassword(event.target.value);
+          }}
+        />{' '}
         <button
           onClick={() => {
             encryptedStorageManager.set(key, value, password).then(isSuccessful => {
               if (isSuccessful) {
-                encryptedStorageManager.get(key, password).then(setPersistedValue);
+                encryptedStorageManager.get(key, password).then(setStoredValue);
               }
             });
           }}
         >
           {'Set value'}
-        </button>{' '}
-        <button
-          onClick={() => {
-            if (encryptedStorageManager.delete(key)) {
-              encryptedStorageManager.get(key, password).then(setPersistedValue);
-            }
-          }}
-        >
-          {'Delete value'}
         </button>
       </p>
 
-      {'Persisted value: '}
-      <FormattedJSON value={persistedValue} />
+      {'Stored value: '}
+      <FormattedJSON value={storedValue} />
     </>
   );
 }

--- a/web/example/src/examples/LocalStorageExample.tsx
+++ b/web/example/src/examples/LocalStorageExample.tsx
@@ -23,7 +23,7 @@ export function LocalStorageExample() {
             rerender();
           }}
         >
-          {'Clear value'}
+          {'❌ Delete value'}
         </button>
       </p>
 

--- a/web/racehorse/src/main/createBiometricEncryptedStorageManager.ts
+++ b/web/racehorse/src/main/createBiometricEncryptedStorageManager.ts
@@ -3,8 +3,19 @@ import { BiometricAuthenticator } from './createBiometricManager';
 import { Scheduler } from './createScheduler';
 
 export interface BiometricConfig {
+  /**
+   * The title of the authentication popup.
+   */
   title?: string;
+
+  /**
+   * The subtitle of the authentication popup.
+   */
   subtitle?: string;
+
+  /**
+   * The description label of the authentication popup.
+   */
   description?: string;
 
   /**
@@ -14,6 +25,8 @@ export interface BiometricConfig {
 
   /**
    * The list of allowed authenticators.
+   *
+   * @default [BiometricAuthenticator.STRONG]
    */
   authenticators?: BiometricAuthenticator[];
 }
@@ -27,7 +40,9 @@ export interface BiometricEncryptedStorageManager {
    * @param key A key to set.
    * @param value A value to write.
    * @param config The options of the biometric prompt.
-   * @return `true` if the value was written to the storage, or `false` otherwise.
+   * @return `true` if the value was written to the storage, or `false` if authentication has failed.
+   * @throws InvalidAlgorithmParameterException At least one biometric must be enrolled to create keys requiring user
+   * authentication for every use. Check {@link BiometricManager.getBiometricStatus} before setting the key.
    */
   set(key: string, value: string, config?: BiometricConfig): Promise<boolean>;
 
@@ -36,7 +51,12 @@ export interface BiometricEncryptedStorageManager {
    *
    * **Note:** This is a UI-blocking operation. All consequent UI operations are suspended until this one is completed.
    *
-   * @returns The deciphered value, or `null` if key wasn't found or if password is incorrect.
+   * @returns The deciphered value, or `null` if key wasn't found, or authentication has failed.
+   * @throws InvalidAlgorithmParameterException At least one biometric must be enrolled to create keys requiring user
+   * authentication for every use. Check {@link BiometricManager.getBiometricStatus} before reading the key.
+   * @throws KeyPermanentlyInvalidatedException Indicates that the key can no longer be read because it has been
+   * permanently invalidated (for example, because of the biometric enrollment). Set a new value or delete the key to
+   * recover from this error.
    */
   get(key: string, config?: BiometricConfig): Promise<string | null>;
 

--- a/web/racehorse/src/main/createBiometricEncryptedStorageManager.ts
+++ b/web/racehorse/src/main/createBiometricEncryptedStorageManager.ts
@@ -29,6 +29,19 @@ export interface BiometricConfig {
    * @default [BiometricAuthenticator.STRONG]
    */
   authenticators?: BiometricAuthenticator[];
+
+  /**
+   * The duration in seconds for which this key is authorized to be used after the user is successfully authenticated or
+   * -1 if user authentication is required every time the key is accessed.
+   *
+   * If value is greater or equal to 0, then key won't be invalidated by biometric enrollment.
+   *
+   * **Note:** This option is only applicable when the key is set for the first time. To change this option, delete and
+   * set the key again with the updated config.
+   *
+   * @default -1
+   */
+  authenticationValidityDuration?: number;
 }
 
 export interface BiometricEncryptedStorageManager {
@@ -43,6 +56,8 @@ export interface BiometricEncryptedStorageManager {
    * @return `true` if the value was written to the storage, or `false` if authentication has failed.
    * @throws InvalidAlgorithmParameterException At least one biometric must be enrolled to create keys requiring user
    * authentication for every use. Check {@link BiometricManager.getBiometricStatus} before setting the key.
+   * @throws IllegalArgumentException Device credential is not supported on API 28 and below.
+   * @throws IllegalArgumentException Crypto-based authentication is not supported for Class 2 (Weak) biometrics.
    */
   set(key: string, value: string, config?: BiometricConfig): Promise<boolean>;
 
@@ -57,6 +72,8 @@ export interface BiometricEncryptedStorageManager {
    * @throws KeyPermanentlyInvalidatedException Indicates that the key can no longer be read because it has been
    * permanently invalidated (for example, because of the biometric enrollment). Set a new value or delete the key to
    * recover from this error.
+   * @throws IllegalArgumentException Device credential is not supported on API 28 and below.
+   * @throws IllegalArgumentException Crypto-based authentication is not supported for Class 2 (Weak) biometrics.
    */
   get(key: string, config?: BiometricConfig): Promise<string | null>;
 
@@ -66,7 +83,7 @@ export interface BiometricEncryptedStorageManager {
   has(key: string): boolean;
 
   /**
-   * Deletes the encrypted value associated with the key.
+   * Deletes the key and the associated encrypted value.
    *
    * @returns `true` if the key was deleted, or `false` if the key didn't exist.
    */

--- a/web/racehorse/src/main/createBiometricManager.ts
+++ b/web/racehorse/src/main/createBiometricManager.ts
@@ -6,14 +6,14 @@ import { Scheduler } from './createScheduler';
  */
 export const BiometricAuthenticator = {
   /**
-   * Any biometric (e.g. fingerprint, iris, or face) on the device that meets or exceeds the requirements for
-   * **Class 3**, as defined by the Android CDD.
+   * Any biometric (e.g. fingerprint, iris, or face) on the device that meets or exceeds the requirements for Class 3,
+   * as defined by the Android CDD.
    */
   BIOMETRIC_STRONG: 'biometric_strong',
 
   /**
-   * Any biometric (e.g. fingerprint, iris, or face) on the device that meets or exceeds the requirements for
-   * **Class 2**, as defined by the Android CDD.
+   * Any biometric (e.g. fingerprint, iris, or face) on the device that meets or exceeds the requirements for Class 2,
+   * as defined by the Android CDD.
    */
   BIOMETRIC_WEAK: 'biometric_weak',
 


### PR DESCRIPTION
Authentication timeout can now be specified for each key separately:

```ts
biometricEncryptedStorageManager.set('key', 'value', {
  authenticators: [
    BiometricAuthenticator.STRONG,
    BiometricAuthenticator.DEVICE_CREDENTIAL
  ],
  authenticationValidityDuration: 5 // seconds
});
```